### PR TITLE
Feature : 공연 장바구니 추가

### DIFF
--- a/src/main/kotlin/com/flab/ticketing/order/controller/OrderController.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/controller/OrderController.kt
@@ -1,0 +1,4 @@
+package com.flab.ticketing.order.controller
+
+class OrderController {
+}

--- a/src/main/kotlin/com/flab/ticketing/order/controller/ReservationController.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/controller/ReservationController.kt
@@ -1,0 +1,31 @@
+package com.flab.ticketing.order.controller
+
+import com.flab.ticketing.auth.dto.service.AuthenticatedUserDto
+import com.flab.ticketing.auth.resolver.annotation.LoginUser
+import com.flab.ticketing.order.service.ReservationService
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+
+@RestController
+@RequestMapping("/api/reservations")
+class ReservationController(
+    private val reservationService: ReservationService
+) {
+
+    @PostMapping("/{performanceUid}/dates/{dateUid}/seats/{seatUid}")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun reservate(
+        @LoginUser user: AuthenticatedUserDto,
+        @PathVariable performanceUid: String,
+        @PathVariable dateUid: String,
+        @PathVariable seatUid: String
+    ) {
+        reservationService.reservate(
+            user.uid,
+            performanceUid,
+            dateUid,
+            seatUid
+        )
+    }
+}

--- a/src/main/kotlin/com/flab/ticketing/order/entity/Cart.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/entity/Cart.kt
@@ -1,0 +1,26 @@
+package com.flab.ticketing.order.entity
+
+import com.flab.ticketing.user.entity.User
+import jakarta.persistence.*
+
+
+@Entity
+@Table(
+    name = "carts",
+    uniqueConstraints = [UniqueConstraint(
+        name = "reservate_unique",
+        columnNames = ["seat_uid", "date_uid"]
+    )]
+)
+class Cart(
+
+    @Id @GeneratedValue
+    val id: Long,
+
+    val seatUid: String,
+    val dateUid: String,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    val user: User,
+)

--- a/src/main/kotlin/com/flab/ticketing/order/entity/Cart.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/entity/Cart.kt
@@ -9,7 +9,7 @@ import jakarta.persistence.*
 @Table(
     name = "carts",
     uniqueConstraints = [UniqueConstraint(
-        name = "reservate_unique",
+        name = "ux_seat_uid_date_uid",
         columnNames = ["seat_uid", "date_uid"]
     )]
 )

--- a/src/main/kotlin/com/flab/ticketing/order/entity/Cart.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/entity/Cart.kt
@@ -1,6 +1,8 @@
 package com.flab.ticketing.order.entity
 
 import com.flab.ticketing.common.entity.BaseEntity
+import com.flab.ticketing.performance.entity.PerformanceDateTime
+import com.flab.ticketing.performance.entity.PerformancePlaceSeat
 import com.flab.ticketing.user.entity.User
 import jakarta.persistence.*
 
@@ -10,14 +12,24 @@ import jakarta.persistence.*
     name = "carts",
     uniqueConstraints = [UniqueConstraint(
         name = "ux_seat_uid_date_uid",
-        columnNames = ["seat_uid", "date_uid"]
+        columnNames = ["seat_id", "performance_datetime_id"]
     )]
 )
 class Cart(
-    val seatUid: String,
-    val dateUid: String,
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @Column(unique = true, updatable = false)
+    val uid: String,
+
+    @ManyToOne
+    @JoinColumn(name = "seat_id")
+    val seat: PerformancePlaceSeat,
+
+
+    @ManyToOne
+    @JoinColumn(name = "performance_datetime_id")
+    val performanceDateTime: PerformanceDateTime,
+
+    @ManyToOne
     @JoinColumn(name = "user_id")
     val user: User,
 ) : BaseEntity()

--- a/src/main/kotlin/com/flab/ticketing/order/entity/Cart.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/entity/Cart.kt
@@ -1,5 +1,6 @@
 package com.flab.ticketing.order.entity
 
+import com.flab.ticketing.common.entity.BaseEntity
 import com.flab.ticketing.user.entity.User
 import jakarta.persistence.*
 
@@ -13,14 +14,10 @@ import jakarta.persistence.*
     )]
 )
 class Cart(
-
-    @Id @GeneratedValue
-    val id: Long,
-
     val seatUid: String,
     val dateUid: String,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     val user: User,
-)
+) : BaseEntity()

--- a/src/main/kotlin/com/flab/ticketing/order/entity/Order.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/entity/Order.kt
@@ -14,7 +14,7 @@ class Order(
     @JoinColumn(name = "ordered_user_id")
     val user: User,
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "order")
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "order", cascade = [CascadeType.ALL])
     val reservations: MutableList<Reservation> = mutableListOf(),
 
     @Embedded

--- a/src/main/kotlin/com/flab/ticketing/order/exception/OrderErrorInfos.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/exception/OrderErrorInfos.kt
@@ -1,0 +1,9 @@
+package com.flab.ticketing.order.exception
+
+import com.flab.ticketing.common.exception.ErrorInfo
+
+enum class OrderErrorInfos(override val code: String, override val message: String) : ErrorInfo {
+
+    ALREADY_RESERVATED("ORDER-001", "이미 예약되었습니다.")
+
+}

--- a/src/main/kotlin/com/flab/ticketing/order/repository/CartRepository.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/repository/CartRepository.kt
@@ -1,0 +1,8 @@
+package com.flab.ticketing.order.repository
+
+import com.flab.ticketing.order.entity.Cart
+import org.springframework.data.repository.CrudRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface CartRepository : CrudRepository<Cart, Long>

--- a/src/main/kotlin/com/flab/ticketing/order/repository/CartRepository.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/repository/CartRepository.kt
@@ -1,8 +1,13 @@
 package com.flab.ticketing.order.repository
 
 import com.flab.ticketing.order.entity.Cart
+import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.repository.CrudRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface CartRepository : CrudRepository<Cart, Long>
+interface CartRepository : JpaRepository<Cart, Long> {
+    
+    fun save(cart: Cart)
+    fun findByDateUidAndSeatUid(dateUid: String, seatUid: String): Cart?
+}

--- a/src/main/kotlin/com/flab/ticketing/order/repository/CartRepository.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/repository/CartRepository.kt
@@ -2,12 +2,15 @@ package com.flab.ticketing.order.repository
 
 import com.flab.ticketing.order.entity.Cart
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.repository.CrudRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 
 @Repository
 interface CartRepository : JpaRepository<Cart, Long> {
-    
+
     fun save(cart: Cart)
-    fun findByDateUidAndSeatUid(dateUid: String, seatUid: String): Cart?
+
+    @Query("SELECT c FROM Cart c WHERE c.performanceDateTime.uid = :dateUid AND c.seat.uid = :seatUid")
+    fun findByDateUidAndSeatUid(@Param("dateUid") dateUid: String, @Param("seatUid") seatUid: String): Cart?
 }

--- a/src/main/kotlin/com/flab/ticketing/order/repository/ReservationRepository.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/repository/ReservationRepository.kt
@@ -15,5 +15,16 @@ interface ReservationRepository : CrudRepository<Reservation, Long> {
                 "WHERE r.performanceDateTime.uid = :dateUid " +
                 "AND r.seat.place.id = :placeId"
     )
-    fun findReservatedSeatUids(@Param("placeId") id: Long, @Param("dateUid") dateUid: String): List<String>
+    fun findReservatedSeatUids(@Param("placeId") placeId: Long, @Param("dateUid") dateUid: String): List<String>
+
+
+    @Query(
+        "SELECT r FROM Reservation r " +
+                "WHERE r.performanceDateTime.uid = :dateUid " +
+                "AND r.seat.uid = :seatId"
+    )
+    fun findReservationBySeatUidAndDateUid(
+        @Param("seatId") seatId: String,
+        @Param("dateUid") dateUid: String
+    ): Reservation?
 }

--- a/src/main/kotlin/com/flab/ticketing/order/service/ReservationService.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/service/ReservationService.kt
@@ -1,0 +1,67 @@
+package com.flab.ticketing.order.service
+
+import com.flab.ticketing.auth.exception.AuthErrorInfos
+import com.flab.ticketing.common.exception.DuplicatedException
+import com.flab.ticketing.common.exception.InvalidValueException
+import com.flab.ticketing.common.exception.NotFoundException
+import com.flab.ticketing.common.exception.UnAuthorizedException
+import com.flab.ticketing.order.entity.Cart
+import com.flab.ticketing.order.exception.OrderErrorInfos
+import com.flab.ticketing.order.repository.CartRepository
+import com.flab.ticketing.order.repository.ReservationRepository
+import com.flab.ticketing.performance.exception.PerformanceErrorInfos
+import com.flab.ticketing.performance.repository.PerformanceDateRepository
+import com.flab.ticketing.performance.repository.PerformanceRepository
+import com.flab.ticketing.user.entity.repository.UserRepository
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.stereotype.Service
+
+
+@Service
+class ReservationService(
+    private val userRepository: UserRepository,
+    private val reservationRepository: ReservationRepository,
+    private val performanceRepository: PerformanceRepository,
+    private val performanceDateRepository: PerformanceDateRepository,
+    private val cartRepository: CartRepository
+) {
+
+    fun reservate(
+        userUid: String,
+        performanceUid: String,
+        dateUid: String,
+        seatUid: String
+    ) {
+        val user = userRepository.findByUid(userUid) ?: throw UnAuthorizedException(AuthErrorInfos.USER_INFO_NOT_FOUND)
+
+        val performance =
+            performanceRepository.findPerformanceByUidJoinWithPlaceAndSeat(performanceUid)
+                ?: throw NotFoundException(PerformanceErrorInfos.PERFORMANCE_NOT_FOUND)
+
+        val performanceDateTime = performanceDateRepository.findByUid(dateUid)
+            ?: throw NotFoundException(PerformanceErrorInfos.INVALID_PERFORMANCE_DATE)
+
+        // performance에 performanceDate가 속했는지 검증
+        if (performanceDateTime.performance != performance) {
+            throw InvalidValueException(PerformanceErrorInfos.INVALID_PERFORMANCE_DATE)
+        }
+
+        // performancePlace에 seat가 속했는지 검증
+        if (!performance.performancePlace.seats.map { it.uid }.contains(seatUid)) {
+            throw InvalidValueException(PerformanceErrorInfos.PERFORMANCE_SEAT_INFO_INVALID)
+        }
+
+        // 예약이 존재하는지 확인
+        if (reservationRepository.findReservationBySeatUidAndDateUid(seatUid, dateUid) != null) {
+            throw DuplicatedException(OrderErrorInfos.ALREADY_RESERVATED)
+        }
+
+        try {
+            cartRepository.save(Cart(seatUid, dateUid, user))
+        } catch (e: DataIntegrityViolationException) {
+            throw DuplicatedException(OrderErrorInfos.ALREADY_RESERVATED)
+        }
+
+    }
+
+}

--- a/src/main/kotlin/com/flab/ticketing/performance/exception/PerformanceErrorInfos.kt
+++ b/src/main/kotlin/com/flab/ticketing/performance/exception/PerformanceErrorInfos.kt
@@ -6,5 +6,6 @@ enum class PerformanceErrorInfos(override val code: String, override val message
 
     PERFORMANCE_NOT_FOUND("PERFORMANCE-001", "공연 정보를 조회할 수 없습니다."),
     INVALID_PERFORMANCE_DATE("PERFORMANCE-002", "공연 날짜의 정보가 올바르지 않습니다."),
-    PERFORMANCE_ALREADY_PASSED("PERFORMANCE-003", "이미 종료된 공연입니다.")
+    PERFORMANCE_ALREADY_PASSED("PERFORMANCE-003", "이미 종료된 공연입니다."),
+    PERFORMANCE_SEAT_INFO_INVALID("PERFORMANCE-004", "좌석 정보가 올바르지 않습니다.")
 }

--- a/src/main/kotlin/com/flab/ticketing/user/entity/repository/UserRepository.kt
+++ b/src/main/kotlin/com/flab/ticketing/user/entity/repository/UserRepository.kt
@@ -7,4 +7,6 @@ import org.springframework.stereotype.Repository
 @Repository
 interface UserRepository : CrudRepository<User, Long> {
     fun findByEmail(email: String): User?
+
+    fun findByUid(uid: String): User?
 }

--- a/src/test/kotlin/com/flab/ticketing/order/integration/ReservationIntegrationTest.kt
+++ b/src/test/kotlin/com/flab/ticketing/order/integration/ReservationIntegrationTest.kt
@@ -1,0 +1,210 @@
+package com.flab.ticketing.order.integration
+
+import com.flab.ticketing.auth.dto.service.AuthenticatedUserDto
+import com.flab.ticketing.auth.dto.service.CustomUserDetailsDto
+import com.flab.ticketing.auth.utils.JwtTokenProvider
+import com.flab.ticketing.common.IntegrationTest
+import com.flab.ticketing.common.OrderTestDataGenerator
+import com.flab.ticketing.common.PerformanceTestDataGenerator
+import com.flab.ticketing.common.UserTestDataGenerator
+import com.flab.ticketing.order.entity.Cart
+import com.flab.ticketing.order.entity.Order
+import com.flab.ticketing.order.exception.OrderErrorInfos
+import com.flab.ticketing.order.repository.CartRepository
+import com.flab.ticketing.order.repository.OrderRepository
+import com.flab.ticketing.performance.entity.Performance
+import com.flab.ticketing.performance.repository.PerformancePlaceRepository
+import com.flab.ticketing.performance.repository.PerformanceRepository
+import com.flab.ticketing.performance.repository.RegionRepository
+import com.flab.ticketing.user.entity.User
+import com.flab.ticketing.user.entity.repository.UserRepository
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
+import io.kotest.matchers.equals.shouldBeEqual
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers
+import java.time.ZonedDateTime
+
+class ReservationIntegrationTest : IntegrationTest() {
+
+    @Autowired
+    private lateinit var performanceRepository: PerformanceRepository
+
+    @Autowired
+    private lateinit var userRepository: UserRepository
+
+    @Autowired
+    private lateinit var regionRepository: RegionRepository
+
+    @Autowired
+    private lateinit var placeRepository: PerformancePlaceRepository
+
+    @Autowired
+    private lateinit var orderRepository: OrderRepository
+
+    @Autowired
+    private lateinit var jwtTokenProvider: JwtTokenProvider
+
+    @Autowired
+    private lateinit var cartRepository: CartRepository
+
+    init {
+
+        given("공연 정보가 존재할 때") {
+            val performance = PerformanceTestDataGenerator.createPerformance(
+                showTimeStartDateTime = ZonedDateTime.now().plusDays(1)
+            )
+            val performanceDateTime = performance.performanceDateTime[0]
+            val place = performance.performancePlace
+
+            val user = UserTestDataGenerator.createUser()
+
+            savePerformance(listOf(performance))
+            userRepository.save(user)
+
+            val jwt = createJwt(user)
+            `when`("로그인된 사용자가 에약되지 않은 좌석에 예약을 시도할 시") {
+                val reservateSeat = place.seats[0]
+
+                val uri =
+                    "/api/reservations/${performance.uid}/dates/${performanceDateTime.uid}/seats/${reservateSeat.uid}"
+
+                val mvcResult = mockMvc.perform(
+                    MockMvcRequestBuilders.post(uri)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer $jwt")
+                )
+                    .andDo(MockMvcResultHandlers.print())
+                    .andReturn()
+
+                then("201 CREATED를 반환하고 DB에 예약 정보를 저장한다.") {
+                    mvcResult.response.status shouldBe HttpStatus.CREATED.value()
+
+                    val actual = cartRepository.findByDateUidAndSeatUid(performanceDateTime.uid, reservateSeat.uid)
+
+                    actual!!.user shouldBeEqual user
+                    actual.dateUid shouldBeEqual performanceDateTime.uid
+                    actual.seatUid shouldBeEqual reservateSeat.uid
+                }
+            }
+        }
+
+        given("공연 정보가 존재할 때 - 카트 중복") {
+            val performance = PerformanceTestDataGenerator.createPerformance(
+                showTimeStartDateTime = ZonedDateTime.now().plusDays(1)
+            )
+            val performanceDateTime = performance.performanceDateTime[0]
+            val place = performance.performancePlace
+            val reservateSeat = place.seats[0]
+
+            val user = UserTestDataGenerator.createUser()
+
+            savePerformance(listOf(performance))
+            userRepository.save(user)
+            cartRepository.save(Cart(reservateSeat.uid, performanceDateTime.uid, user))
+
+            val jwt = createJwt(user)
+            `when`("이미 카트에 존재하는 좌석을 예매할 시") {
+                val uri =
+                    "/api/reservations/${performance.uid}/dates/${performanceDateTime.uid}/seats/${reservateSeat.uid}"
+
+                val mvcResult = mockMvc.perform(
+                    MockMvcRequestBuilders.post(uri)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer $jwt")
+                )
+                    .andDo(MockMvcResultHandlers.print())
+                    .andReturn()
+                then("409 conflict 오류를 throw한다.") {
+                    checkError(mvcResult, HttpStatus.CONFLICT, OrderErrorInfos.ALREADY_RESERVATED)
+                }
+            }
+        }
+
+        given("공연 정보가 존재할 때 - 예약 중복") {
+            val performance = PerformanceTestDataGenerator.createPerformance(
+                showTimeStartDateTime = ZonedDateTime.now().plusDays(1)
+            )
+            val performanceDateTime = performance.performanceDateTime[0]
+            val place = performance.performancePlace
+            val reservateSeat = place.seats[0]
+
+            val user = UserTestDataGenerator.createUser()
+
+            val reservations = OrderTestDataGenerator.createReservations(
+                performanceDateTime,
+                place.seats.subList(0, 1),
+                OrderTestDataGenerator.createOrder(user = user)
+            )
+
+            savePerformance(listOf(performance))
+            userRepository.save(user)
+            saveOrder(reservations[0].order)
+
+            val jwt = createJwt(user)
+            `when`("이미 카트에 존재하는 좌석을 예매할 시") {
+                val uri =
+                    "/api/reservations/${performance.uid}/dates/${performanceDateTime.uid}/seats/${reservateSeat.uid}"
+
+                val mvcResult = mockMvc.perform(
+                    MockMvcRequestBuilders.post(uri)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer $jwt")
+                )
+                    .andDo(MockMvcResultHandlers.print())
+                    .andReturn()
+                then("409 conflict 오류를 throw한다.") {
+                    checkError(mvcResult, HttpStatus.CONFLICT, OrderErrorInfos.ALREADY_RESERVATED)
+                }
+            }
+        }
+    }
+
+    override suspend fun afterEach(testCase: TestCase, result: TestResult) {
+        super.afterEach(testCase, result)
+
+        PerformanceTestDataGenerator.reset()
+        withContext(Dispatchers.IO) {
+            cartRepository.deleteAll()
+            orderRepository.deleteAll()
+            userRepository.deleteAll()
+            performanceRepository.deleteAll()
+            placeRepository.deleteAll()
+            regionRepository.deleteAll()
+        }
+
+
+    }
+
+    private fun savePerformance(performances: List<Performance>) {
+        regionRepository.save(performances[0].performancePlace.region)
+        placeRepository.save(performances[0].performancePlace)
+
+        performances.forEach {
+            performanceRepository.save(it)
+        }
+    }
+
+
+    private fun createJwt(user: User): String {
+        return jwtTokenProvider.sign(
+            AuthenticatedUserDto.of(
+                CustomUserDetailsDto(
+                    user.uid,
+                    user.email,
+                    user.password,
+                    user.nickname
+                )
+            ),
+            mutableListOf()
+        )
+    }
+
+    private fun saveOrder(order: Order) {
+        orderRepository.save(order)
+    }
+
+}

--- a/src/test/kotlin/com/flab/ticketing/order/integration/ReservationIntegrationTest.kt
+++ b/src/test/kotlin/com/flab/ticketing/order/integration/ReservationIntegrationTest.kt
@@ -88,8 +88,8 @@ class ReservationIntegrationTest : IntegrationTest() {
                     val actual = cartRepository.findByDateUidAndSeatUid(performanceDateTime.uid, reservateSeat.uid)
 
                     actual!!.user shouldBeEqual user
-                    actual.dateUid shouldBeEqual performanceDateTime.uid
-                    actual.seatUid shouldBeEqual reservateSeat.uid
+                    actual.performanceDateTime shouldBeEqual performanceDateTime
+                    actual.seat shouldBeEqual reservateSeat
                 }
             }
         }
@@ -106,7 +106,7 @@ class ReservationIntegrationTest : IntegrationTest() {
 
             savePerformance(listOf(performance))
             userRepository.save(user)
-            cartRepository.save(Cart(reservateSeat.uid, performanceDateTime.uid, user))
+            cartRepository.save(Cart("cart001", reservateSeat, performanceDateTime, user))
 
             val jwt = createJwt(user)
             `when`("이미 카트에 존재하는 좌석을 예매할 시") {

--- a/src/test/kotlin/com/flab/ticketing/order/service/ReservationServiceTest.kt
+++ b/src/test/kotlin/com/flab/ticketing/order/service/ReservationServiceTest.kt
@@ -1,0 +1,196 @@
+package com.flab.ticketing.order.service
+
+import com.flab.ticketing.auth.exception.AuthErrorInfos
+import com.flab.ticketing.common.OrderTestDataGenerator
+import com.flab.ticketing.common.PerformanceTestDataGenerator
+import com.flab.ticketing.common.UnitTest
+import com.flab.ticketing.common.UserTestDataGenerator
+import com.flab.ticketing.common.exception.DuplicatedException
+import com.flab.ticketing.common.exception.InvalidValueException
+import com.flab.ticketing.common.exception.NotFoundException
+import com.flab.ticketing.common.exception.UnAuthorizedException
+import com.flab.ticketing.order.entity.Cart
+import com.flab.ticketing.order.entity.Reservation
+import com.flab.ticketing.order.exception.OrderErrorInfos
+import com.flab.ticketing.order.repository.CartRepository
+import com.flab.ticketing.order.repository.ReservationRepository
+import com.flab.ticketing.performance.exception.PerformanceErrorInfos
+import com.flab.ticketing.performance.repository.PerformanceDateRepository
+import com.flab.ticketing.performance.repository.PerformanceRepository
+import com.flab.ticketing.user.entity.repository.UserRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.dao.DataIntegrityViolationException
+
+class ReservationServiceTest : UnitTest() {
+    private val performanceRepository: PerformanceRepository = mockk()
+    private val performanceDateRepository: PerformanceDateRepository = mockk()
+    private val userRepository: UserRepository = mockk()
+    private val cartRepository: CartRepository = mockk()
+    private val reservationRepository: ReservationRepository = mockk()
+
+    private val reservationService =
+        ReservationService(
+            userRepository,
+            reservationRepository,
+            performanceRepository,
+            performanceDateRepository,
+            cartRepository
+        )
+
+    init {
+        "예약 정보를 저장할 수 있다." {
+            val user = UserTestDataGenerator.createUser()
+            val performance = PerformanceTestDataGenerator.createPerformance()
+            val performanceDateTime = performance.performanceDateTime[0]
+            val seatUid = performance.performancePlace.seats[0].uid
+
+
+            every { userRepository.findByUid(user.uid) } returns user
+            every { performanceRepository.findPerformanceByUidJoinWithPlaceAndSeat(performance.uid) } returns performance
+            every { performanceDateRepository.findByUid(performanceDateTime.uid) } returns performanceDateTime
+            every { cartRepository.save(any()) } returns Unit
+            every {
+                reservationRepository.findReservationBySeatUidAndDateUid(
+                    seatUid,
+                    performanceDateTime.uid
+                )
+            } returns null
+
+
+            reservationService.reservate(user.uid, performance.uid, performanceDateTime.uid, seatUid)
+
+            verify { cartRepository.save(Cart(seatUid, performanceDateTime.uid, user)) }
+
+        }
+
+        "예약시 사용자가 DB에 저장되어 있지 않다면 UnauthorizedException을 throw한다." {
+            val userUid = "user001"
+            val performanceUid = "perform001"
+            val dateUid = "date001"
+            val seatUid = "seat001"
+
+            every { userRepository.findByUid(userUid) } returns null
+
+            val e = shouldThrow<UnAuthorizedException> {
+                reservationService.reservate(userUid, performanceUid, dateUid, seatUid)
+            }
+
+            e.info shouldBe AuthErrorInfos.USER_INFO_NOT_FOUND
+        }
+
+        "예약시 Performance가 DB에 저장되지 않다면 NotFoundException을 throw한다." {
+            val user = UserTestDataGenerator.createUser()
+            val performanceUid = "perform001"
+            val dateUid = "date001"
+            val seatUid = "seat001"
+
+            every { userRepository.findByUid(user.uid) } returns user
+            every { performanceRepository.findPerformanceByUidJoinWithPlaceAndSeat(performanceUid) } returns null
+
+            val e = shouldThrow<NotFoundException> {
+                reservationService.reservate(user.uid, performanceUid, dateUid, seatUid)
+            }
+
+            e.info shouldBe PerformanceErrorInfos.PERFORMANCE_NOT_FOUND
+        }
+
+        "예약시 PerformanceDateTime이 DB에 저장되어 있지 않다면 NotFoundException을 throw한다. " {
+            val user = UserTestDataGenerator.createUser()
+            val performance = PerformanceTestDataGenerator.createPerformance()
+            val dateUid = "date001"
+            val seatUid = "seat001"
+
+            every { userRepository.findByUid(user.uid) } returns user
+            every { performanceRepository.findPerformanceByUidJoinWithPlaceAndSeat(performance.uid) } returns performance
+            every { performanceDateRepository.findByUid(dateUid) } returns null
+
+            val e = shouldThrow<NotFoundException> {
+                reservationService.reservate(user.uid, performance.uid, dateUid, seatUid)
+            }
+
+            e.info shouldBe PerformanceErrorInfos.INVALID_PERFORMANCE_DATE
+        }
+
+        "예약시 공연 장소에 seatUid가 포함되어 있지 않다면 InvalidValueException을 throw한다." {
+            val user = UserTestDataGenerator.createUser()
+            val performance = PerformanceTestDataGenerator.createPerformance()
+            val performanceDateTime = performance.performanceDateTime[0]
+            val seatUid = "invalidUid"
+
+
+            every { userRepository.findByUid(user.uid) } returns user
+            every { performanceRepository.findPerformanceByUidJoinWithPlaceAndSeat(performance.uid) } returns performance
+            every { performanceDateRepository.findByUid(performanceDateTime.uid) } returns performanceDateTime
+
+            val e = shouldThrow<InvalidValueException> {
+                reservationService.reservate(user.uid, performance.uid, performanceDateTime.uid, seatUid)
+            }
+
+            e.info shouldBe PerformanceErrorInfos.PERFORMANCE_SEAT_INFO_INVALID
+
+        }
+
+        "예약 정보가 이미 저장되어 있다면 DuplicatedException을 throw한다." {
+            val user = UserTestDataGenerator.createUser()
+            val performance = PerformanceTestDataGenerator.createPerformance()
+            val performanceDateTime = performance.performanceDateTime[0]
+            val seatUid = performance.performancePlace.seats[0].uid
+            val reservation = Reservation(
+                performanceDateTime,
+                performance.performancePlace.seats[0],
+                OrderTestDataGenerator.createOrder(user = user)
+            )
+
+            every { userRepository.findByUid(user.uid) } returns user
+            every { performanceRepository.findPerformanceByUidJoinWithPlaceAndSeat(performance.uid) } returns performance
+            every { performanceDateRepository.findByUid(performanceDateTime.uid) } returns performanceDateTime
+            every { cartRepository.save(any()) } returns Unit
+            every {
+                reservationRepository.findReservationBySeatUidAndDateUid(
+                    seatUid,
+                    performanceDateTime.uid
+                )
+            } returns reservation
+
+            val e = shouldThrow<DuplicatedException> {
+                reservationService.reservate(user.uid, performance.uid, performanceDateTime.uid, seatUid)
+            }
+
+            e.info shouldBe OrderErrorInfos.ALREADY_RESERVATED
+        }
+
+        "예약시 이미 저장된 Cart가 존재한다면  DuplicatedException을 throw한다." {
+            val user = UserTestDataGenerator.createUser()
+            val performance = PerformanceTestDataGenerator.createPerformance()
+            val performanceDateTime = performance.performanceDateTime[0]
+            val seatUid = performance.performancePlace.seats[0].uid
+
+
+            every { userRepository.findByUid(user.uid) } returns user
+            every { performanceRepository.findPerformanceByUidJoinWithPlaceAndSeat(performance.uid) } returns performance
+            every { performanceDateRepository.findByUid(performanceDateTime.uid) } returns performanceDateTime
+            every { cartRepository.save(any()) } returns Unit
+            every {
+                reservationRepository.findReservationBySeatUidAndDateUid(
+                    seatUid,
+                    performanceDateTime.uid
+                )
+            } returns null
+            every { cartRepository.save(any()) } throws DataIntegrityViolationException("중복!")
+
+            
+            val e = shouldThrow<DuplicatedException> {
+                reservationService.reservate(user.uid, performance.uid, performanceDateTime.uid, seatUid)
+            }
+
+            e.info shouldBe OrderErrorInfos.ALREADY_RESERVATED
+
+
+        }
+    }
+
+}


### PR DESCRIPTION
### 개요
- 특정 공연을 장바구니에 추가하는 API를 작성하였습니다.

### 상세
- 사용자의 request는 다음과 같습니다.
```
POST /api/reservations/{performanceUid}/dates/{performanceDateUid}/seats/{seatUid}
```
- 정상 응답은 `201 CREATED`를 반환합니다.
- 유저의 parameter 중 잘못된 값이 존재할 경우 `400 BAD REQUEST`를 반환합니다.
- 유저 정보를 조회할 수 없을 시 `401 UNAUTHORIZED` 를 반환합니다.
- 중복된 예약이 존재할 시 `409 CONFLICT`를 반환합니다.

### 기타
- 공연의 예약 정보를 조회할 시 CartRepository를 조회하는 기능은 다음 Issue에서 작업하겠습니다.
- 추가적으로 최근에 복잡한 로직들을 다루면서 Service 코드가 많이 지져분해 졌는데, 다음 작업하기 전에 Service코드의 리팩토링 먼저 수행하겠습니다!