### PR TITLE
Feature : 공연 상세 조회 잔여 좌석 조회 장바구니 Count 추가

### DIFF
--- a/src/main/kotlin/com/flab/ticketing/order/repository/CartRepository.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/repository/CartRepository.kt
@@ -16,4 +16,13 @@ interface CartRepository : JpaRepository<Cart, Long> {
 
     @Query("SELECT c FROM Cart c WHERE c.performanceDateTime.uid = :dateUid AND c.seat.uid = :seatUid")
     fun findByDateUidAndSeatUid(@Param("dateUid") dateUid: String, @Param("seatUid") seatUid: String): Cart?
+
+    @Query(
+        "SELECT c.seat.uid FROM Cart c " +
+                "WHERE c.performanceDateTime.uid = :dateUid " +
+                "AND EXISTS(" +
+                " SELECT 1 FROM PerformancePlaceSeat s WHERE s = c.seat " +
+                " AND s.place.id = :placeId)"
+    )
+    fun findSeatUidByDateUidAndPlaceIn(@Param("dateUid") dateUid: String, @Param("placeId") placeId: Long): List<String>
 }

--- a/src/main/kotlin/com/flab/ticketing/order/repository/reader/CartReader.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/repository/reader/CartReader.kt
@@ -13,4 +13,8 @@ class CartReader(
     fun findByUser(userUid: String): List<Cart> {
         return cartRepository.findByUserUid(userUid)
     }
+
+    fun findSeatUidInPlace(placeId: Long, performanceDateTimeUid: String): List<String> {
+        return cartRepository.findSeatUidByDateUidAndPlaceIn(performanceDateTimeUid, placeId)
+    }
 }

--- a/src/main/kotlin/com/flab/ticketing/performance/dto/service/PerformanceDateSummaryResult.kt
+++ b/src/main/kotlin/com/flab/ticketing/performance/dto/service/PerformanceDateSummaryResult.kt
@@ -6,5 +6,6 @@ data class PerformanceDateSummaryResult(
     val uid: String,
     val showTime: ZonedDateTime,
     val totalSeats: Long,
-    val reservedSeats: Long
+    val reservedSeats: Long,
+    val cartSeats: Long,
 )

--- a/src/main/kotlin/com/flab/ticketing/performance/repository/PerformanceRepository.kt
+++ b/src/main/kotlin/com/flab/ticketing/performance/repository/PerformanceRepository.kt
@@ -26,11 +26,12 @@ interface PerformanceRepository : CustomPerformanceRepository,
 
 
     @Query(
-        "SELECT new com.flab.ticketing.performance.dto.service.PerformanceDateSummaryResult(pd.uid, pd.showTime, count(ss), count(rs.seat)) FROM Performance p " +
+        "SELECT new com.flab.ticketing.performance.dto.service.PerformanceDateSummaryResult(pd.uid, pd.showTime, count(ss), count(rs.seat), count(c.seat)) FROM Performance p " +
                 "JOIN p.performanceDateTime pd " +
                 "JOIN p.performancePlace pp " +
                 "JOIN pp.seats ss " +
                 "LEFT JOIN Reservation rs ON ss = rs.seat " +
+                "LEFT JOIN Cart c ON c.seat = ss " +
                 "WHERE p.uid = :uid " +
                 "GROUP BY pd.uid"
     )

--- a/src/main/kotlin/com/flab/ticketing/performance/repository/PerformanceRepository.kt
+++ b/src/main/kotlin/com/flab/ticketing/performance/repository/PerformanceRepository.kt
@@ -31,7 +31,7 @@ interface PerformanceRepository : CustomPerformanceRepository,
                 "JOIN p.performancePlace pp " +
                 "JOIN pp.seats ss " +
                 "LEFT JOIN Reservation rs ON ss = rs.seat " +
-                "LEFT JOIN Cart c ON c.seat = ss " +
+                "LEFT JOIN Cart c ON ss = c.seat " +
                 "WHERE p.uid = :uid " +
                 "GROUP BY pd.uid"
     )

--- a/src/main/kotlin/com/flab/ticketing/performance/service/PerformanceService.kt
+++ b/src/main/kotlin/com/flab/ticketing/performance/service/PerformanceService.kt
@@ -96,7 +96,7 @@ class PerformanceService(
                 it.uid,
                 it.showTime.toLocalDateTime(),
                 it.totalSeats,
-                it.totalSeats - it.reservedSeats
+                it.totalSeats - it.reservedSeats - it.cartSeats
             )
         }
     }

--- a/src/test/kotlin/com/flab/ticketing/performance/integration/PerformanceSearchIntegrationTest.kt
+++ b/src/test/kotlin/com/flab/ticketing/performance/integration/PerformanceSearchIntegrationTest.kt
@@ -592,10 +592,13 @@ class PerformanceSearchIntegrationTest : IntegrationTest() {
                 performance.performancePlace.seats.subList(0, 3),
                 order
             )
+            val carts = createCarts(user, performanceDate, performance.performancePlace.seats.subList(3, 4))
+
 
             userRepository.save(user)
             savePerformance(listOf(performance))
             saveOrder(order)
+            cartRepository.saveAll(carts)
 
             val jwt = createJwt(user)
 
@@ -635,7 +638,7 @@ class PerformanceSearchIntegrationTest : IntegrationTest() {
                                 PerformanceDateDetailResponse.SeatInfo(
                                     place.seats[3].uid,
                                     place.seats[3].name,
-                                    false
+                                    true
                                 )
                             ),
                             listOf(

--- a/src/test/kotlin/com/flab/ticketing/performance/repository/PerformanceRepositoryImplTest.kt
+++ b/src/test/kotlin/com/flab/ticketing/performance/repository/PerformanceRepositoryImplTest.kt
@@ -349,7 +349,8 @@ class PerformanceRepositoryImplTest(
                     uid = it.uid,
                     showTime = it.showTime.withZoneSameInstant(ZoneOffset.ofHours(9)),
                     totalSeats = placeSeats.toLong(),
-                    reservedSeats = 0
+                    reservedSeats = 0,
+                    cartSeats = 0
                 )
             }
 

--- a/src/test/kotlin/com/flab/ticketing/performance/service/PerformanceServiceTest.kt
+++ b/src/test/kotlin/com/flab/ticketing/performance/service/PerformanceServiceTest.kt
@@ -35,6 +35,7 @@ class PerformanceServiceTest : UnitTest() {
             )
 
             val reservedSeats = 2L
+            val cartedSeats = 3L
 
             val givenPerformanceInfo = PerformanceDetailSearchResult(
                 uid = performance.uid,
@@ -51,7 +52,8 @@ class PerformanceServiceTest : UnitTest() {
                     it.uid,
                     it.showTime,
                     performance.performancePlace.seats.size.toLong(),
-                    reservedSeats
+                    reservedSeats,
+                    cartedSeats
                 )
             }
 
@@ -68,7 +70,7 @@ class PerformanceServiceTest : UnitTest() {
                     it.uid,
                     it.showTime.toLocalDateTime(),
                     totalSeatSize,
-                    totalSeatSize - reservedSeats
+                    totalSeatSize - reservedSeats - cartedSeats
                 )
             }
 


### PR DESCRIPTION
### 개요
- 공연 상세 조회시 잔여 좌석에 장바구니의 Count가 포함되도록 로직을 변경하였습니다.



### 관련 이슈
#31 