### PR TITLE
Feat: Spring Actuator 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
     implementation 'com.aventrix.jnanoid:jnanoid:2.0.0'
     implementation 'com.google.zxing:javase:3.5.3'
 

--- a/src/main/kotlin/com/flab/ticketing/auth/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/flab/ticketing/auth/config/SecurityConfig.kt
@@ -37,6 +37,7 @@ class SecurityConfig {
                     .requestMatchers("/api/user/new/**").permitAll()
                     .requestMatchers("/api/user/login").permitAll()
                     .requestMatchers("/api/performances", "/api/performances/*").permitAll()
+                    .requestMatchers("/actuator/**").permitAll()
                     .anyRequest().authenticated()
             }.formLogin { formLogin -> formLogin.disable() }
             .exceptionHandling { it.authenticationEntryPoint(authenticationEntryPoint) }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -107,3 +107,11 @@ logging:
       max-file-size: 10MB
       total-size-cap: 1GB
       max-history: 30
+
+management:
+  server:
+    port: 9090
+  endpoints:
+    web:
+      exposure:
+        include: health, prometheus


### PR DESCRIPTION
### 개요
- Spring Actuator와 Prometheus를 연동하기 위한 Spring Actuator 설정을 진행하였습니다.
- 보안을 위해 Actuator의 포트를 어플리케이션 포트와 구분하였습니다.