### PR TITLE
Fix: 존재하지 않는 URL에 접근 시 404가 아닌 401로 응답하는 문제

### DIFF
--- a/src/main/kotlin/com/flab/ticketing/auth/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/flab/ticketing/auth/config/SecurityConfig.kt
@@ -5,6 +5,7 @@ import com.flab.ticketing.auth.filter.JwtAuthenticateFilter
 import com.flab.ticketing.common.filter.ExceptionHandlerFilter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod
 import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.authentication.AuthenticationProvider
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider
@@ -34,10 +35,13 @@ class SecurityConfig {
             .csrf { csrfConfig -> csrfConfig.disable() }
             .authorizeHttpRequests { authorizedRequests ->
                 authorizedRequests
+                    .requestMatchers(HttpMethod.GET).permitAll()
                     .requestMatchers("/api/user/new/**").permitAll()
                     .requestMatchers("/api/user/login").permitAll()
                     .requestMatchers("/api/performances", "/api/performances/*").permitAll()
-                    .requestMatchers("/actuator/**").permitAll()
+                    .requestMatchers("/actuator").permitAll()
+                    .requestMatchers("/api/orders/**", "/api/reservations/**", "/api/performances/*/dates/**")
+                    .authenticated()
                     .anyRequest().authenticated()
             }.formLogin { formLogin -> formLogin.disable() }
             .exceptionHandling { it.authenticationEntryPoint(authenticationEntryPoint) }

--- a/src/main/kotlin/com/flab/ticketing/auth/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/flab/ticketing/auth/config/SecurityConfig.kt
@@ -35,13 +35,19 @@ class SecurityConfig {
             .csrf { csrfConfig -> csrfConfig.disable() }
             .authorizeHttpRequests { authorizedRequests ->
                 authorizedRequests
-                    .requestMatchers(HttpMethod.GET).permitAll()
+
                     .requestMatchers("/api/user/new/**").permitAll()
                     .requestMatchers("/api/user/login").permitAll()
                     .requestMatchers("/api/performances", "/api/performances/*").permitAll()
                     .requestMatchers("/actuator").permitAll()
-                    .requestMatchers("/api/orders/**", "/api/reservations/**", "/api/performances/*/dates/**")
+                    .requestMatchers(
+                        "/api/health-check",
+                        "/api/orders/**",
+                        "/api/reservations/**",
+                        "/api/performances/*/dates/**"
+                    )
                     .authenticated()
+                    .requestMatchers(HttpMethod.GET).permitAll()
                     .anyRequest().authenticated()
             }.formLogin { formLogin -> formLogin.disable() }
             .exceptionHandling { it.authenticationEntryPoint(authenticationEntryPoint) }

--- a/src/main/kotlin/com/flab/ticketing/common/controller/GlobalControllerAdvice.kt
+++ b/src/main/kotlin/com/flab/ticketing/common/controller/GlobalControllerAdvice.kt
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.servlet.NoHandlerFoundException
 
 
 @RestControllerAdvice
@@ -25,6 +26,11 @@ class GlobalControllerAdvice {
     @ExceptionHandler(NotFoundException::class)
     fun handleNotFoundException(e: BusinessException): ResponseEntity<ErrorResponse> {
         return ResponseEntity(ErrorResponse.of(e.info), HttpStatus.NOT_FOUND)
+    }
+
+    @ExceptionHandler(NoHandlerFoundException::class)
+    fun handleInvalidUrl(): ResponseEntity<ErrorResponse> {
+        return ResponseEntity(ErrorResponse.of(CommonErrorInfos.NOT_FOUND), HttpStatus.NOT_FOUND)
     }
 
     @ExceptionHandler(MethodArgumentNotValidException::class)

--- a/src/main/kotlin/com/flab/ticketing/common/exception/CommonErrorInfos.kt
+++ b/src/main/kotlin/com/flab/ticketing/common/exception/CommonErrorInfos.kt
@@ -5,5 +5,6 @@ enum class CommonErrorInfos(override val code: String, override val message: Str
     INVALID_FIELD("COMMON-001", " 필드의 값이 올바르지 않습니다."),
     SERVICE_ERROR("COMMON-002", "서버 처리 중 알 수 없는 오류가 발생했습니다."),
     INVALID_METHOD("COMMON-003", "HTTP 메소드를 올바르게 설정하지 않았습니다."),
-    EXTERNAL_API_ERROR("COMMON-004", "외부 API 오류가 발생하였습니다.")
+    EXTERNAL_API_ERROR("COMMON-004", "외부 API 오류가 발생하였습니다."),
+    NOT_FOUND("COMMON-005", "자원을 찾을 수 없습니다.")
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
-
+  web:
+    resources:
+      add-mappings: false
   mail:
     sender: ${MAIL_SENDER}
     host: ${MAIL_HOST}
@@ -75,7 +77,9 @@ spring:
     redis:
       host: localhost
       port: 6379
-
+  web:
+    resources:
+      add-mappings: false
 server:
   servlet:
     encoding:

--- a/src/test/kotlin/com/flab/ticketing/common/integrations/CommonIntegrationTest.kt
+++ b/src/test/kotlin/com/flab/ticketing/common/integrations/CommonIntegrationTest.kt
@@ -1,0 +1,75 @@
+package com.flab.ticketing.common.integrations
+
+import com.flab.ticketing.auth.dto.service.AuthenticatedUserDto
+import com.flab.ticketing.auth.utils.JwtTokenProvider
+import com.flab.ticketing.common.IntegrationTest
+import com.flab.ticketing.common.UserTestDataGenerator
+import com.flab.ticketing.common.exception.CommonErrorInfos
+import com.flab.ticketing.user.repository.UserRepository
+import io.kotest.core.test.TestCase
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
+import java.util.*
+
+class CommonIntegrationTest : IntegrationTest() {
+
+    @Autowired
+    private lateinit var userRepository: UserRepository
+
+    @Autowired
+    private lateinit var jwtTokenProvider: JwtTokenProvider
+
+    init {
+
+        given("특정 URL이 존재하지 않을 때") {
+            `when`("사용자가 해당 URL에 접근하고자 하면") {
+                val uri = "/api/notused"
+
+                val mvcResult = mockMvc.perform(get(uri))
+                    .andDo(print())
+                    .andReturn()
+
+                then("404 오류를 throw한다.") {
+                    checkError(mvcResult, HttpStatus.NOT_FOUND, CommonErrorInfos.NOT_FOUND)
+
+                }
+            }
+        }
+
+
+        given("특정 URL이 존재하지 않을 때 - 인증된 사용자") {
+            val user = UserTestDataGenerator.createUser()
+
+            userRepository.save(user)
+
+            val token = jwtTokenProvider.sign(
+                AuthenticatedUserDto(user.uid, user.email, user.nickname),
+                mutableListOf(),
+                Date()
+            )
+            `when`("사용자가 해당 URL에 접근하고자 하면") {
+                val uri = "/api/notused"
+
+                val mvcResult = mockMvc.perform(
+                    get(uri)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer ${token}")
+                )
+                    .andDo(print())
+                    .andReturn()
+
+                then("404 오류를 throw한다.") {
+                    checkError(mvcResult, HttpStatus.NOT_FOUND, CommonErrorInfos.NOT_FOUND)
+
+                }
+            }
+        }
+    }
+
+
+    override suspend fun beforeEach(testCase: TestCase) {
+        userRepository.deleteAll()
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -23,6 +23,9 @@ spring:
     redis:
       host: localhost
       port: 6379
+  web:
+    resources:
+      add-mappings: false
 
 server:
   servlet:


### PR DESCRIPTION
### 개요
- 존재하지 않는 URL에 접근할 시 401이 나타나는 문제가 존재했습니다.
- 401 보단 404를 반환하는게 더욱 적절할 것 같아서 404를 반환하도록 수정하였습니다.

### 상세
- 먼저 404 오류를 BadErrorController(Spring이 기본으로 제공하는 Not Found Exception Handler)가 아닌 커스터마이징한 ExceptionHandler가 처리하도록 하였습니다.
- Spring Security에서 명시적으로 open한 URI를 제외한 모든 요청이 authenticated 처리 되어 있었는데, 모든 GET 요청에 대해서 open하고, 로그인이 필요한 GET 요청은 따로 authenticated 처리를 해주었습니다.

### 참고사항
- 블로그 글에 해당 내용을 정리해 두었는데, 필요하시면 참고해주시면 좋을 것 같습니다! 
https://flannel-dill-7dc.notion.site/Spring-Security-Web-MVC-404-111fc957389c80c98d09e3db653dd396?pvs=4

