### PR TITLE
fix: 이메일 전송 시 SMTP 서버와 연결이 실패하는 오류 해결

### DIFF
--- a/src/main/kotlin/com/flab/ticketing/auth/config/UserConfig.kt
+++ b/src/main/kotlin/com/flab/ticketing/auth/config/UserConfig.kt
@@ -24,21 +24,19 @@ class UserConfig {
         javaMailSender.port = port
         javaMailSender.username = username
         javaMailSender.password = password
-        javaMailSender.setJavaMailProperties(getMailProperties())
+        javaMailSender.javaMailProperties = getMailProperties(host)
 
         return javaMailSender
     }
 
-    private fun getMailProperties(): Properties {
-        val properties = Properties()
-        properties.setProperty("mail.transport.protocol", "smtp")
-        properties.setProperty("mail.debug", "false")
-        properties.setProperty("mail.smtp.auth", "true")
-        properties.setProperty("mail.smtp.starttls.enable", "true")
-        properties.setProperty("mail.smtp.connectiontimeout", "5000")
-        properties.setProperty("mail.smtp.timeout", "3000")
-        properties.setProperty("mail.smtp.writetimeout", "5000")
-        return properties
+    private fun getMailProperties(host: String?): Properties {
+        val props = Properties()
+        props["mail.transport.protocol"] = "smtp"
+        props["mail.smtp.auth"] = "true"
+        props["mail.smtp.starttls.enable"] = "true"
+        props["mail.smtp.ssl.enable"] = "true"
+        props["mail.smtp.ssl.trust"] = host
+        return props
     }
 
 }

--- a/src/test/kotlin/com/flab/ticketing/auth/integration/UserRegisterIntegrationTest.kt
+++ b/src/test/kotlin/com/flab/ticketing/auth/integration/UserRegisterIntegrationTest.kt
@@ -370,9 +370,6 @@ class UserRegisterIntegrationTest : IntegrationTest() {
             }
         }
 
-        beforeSpec {
-            greenMail.start()
-        }
 
         afterContainer {
             greenMail.reset()
@@ -381,10 +378,7 @@ class UserRegisterIntegrationTest : IntegrationTest() {
         afterEach {
             userRepository.deleteAll()
         }
-
-        afterSpec {
-            greenMail.stop()
-        }
+        
 
     }
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -15,7 +15,7 @@ spring:
   #        show_sql: true
   mail:
     sender: noreply@minticketing.com
-    host: 127.0.0.1
+    host: localhost
     port: 3025
     username: foo
     password: foo-pwd


### PR DESCRIPTION
## #️⃣연관된 이슈

> #76 

## 📝작업 내용

> 이메일 전송 시 SMTP 서버와 정상적인 연결을 할 수 있도록 SSL 기능을 추가하였습니다.
> 이에 따른 테스트 코드 설정을 변경하였습니다.


