### PR TITLE
Refactor: Performance 조회 로직 개선 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,15 @@ java {
     }
 }
 
+apply plugin: 'kotlin-spring'
+apply plugin: 'kotlin-jpa'
+
+allOpen {
+    annotation('jakarta.persistence.Entity')
+    annotation('jakarta.persistence.MappedSuperclass')
+    annotation('jakarta.persistence.Embeddable')
+}
+
 repositories {
     mavenCentral()
 }

--- a/src/main/kotlin/com/flab/ticketing/order/entity/Order.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/entity/Order.kt
@@ -28,12 +28,8 @@ class Order(
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "order", cascade = [CascadeType.ALL])
     val reservations: MutableList<Reservation> = mutableListOf()
 
-    var name: String
-
-    init {
-        name = generateName()
-    }
-
+    var name: String = generateName()
+    
     fun addReservation(reservation: Reservation) {
         reservations.add(reservation)
         name = generateName()

--- a/src/main/kotlin/com/flab/ticketing/performance/controller/PerformanceController.kt
+++ b/src/main/kotlin/com/flab/ticketing/performance/controller/PerformanceController.kt
@@ -49,31 +49,6 @@ class PerformanceController(
         return CursoredResponse(null, performances)
     }
 
-    @Operation(
-        summary = "공연 목록 조회 v2",
-        description = "조건 없이 공연 목록을 조회합니다. 커서 기반 페이징을 지원합니다.",
-        responses = [
-            ApiResponse(responseCode = "200", description = "성공적으로 공연 목록을 조회함")
-        ]
-    )
-    @GetMapping("/v2")
-    fun getListV2(
-        @ParameterObject @ModelAttribute cursorInfoDto: CursorInfoDto
-    ): CursoredResponse<PerformanceSummarySearchResult> {
-        val performances = performanceService.search(
-            CursorInfoDto(cursorInfoDto.cursor, cursorInfoDto.limit + 1)
-        )
-
-        if (performances.size == cursorInfoDto.limit + 1) {
-            return CursoredResponse(
-                performances[cursorInfoDto.limit].uid,
-                performances.dropLast(1)
-            )
-        }
-
-        return CursoredResponse(null, performances)
-    }
-
 
     @Operation(
         summary = "공연 상세 정보 조회",

--- a/src/main/kotlin/com/flab/ticketing/performance/controller/PerformanceController.kt
+++ b/src/main/kotlin/com/flab/ticketing/performance/controller/PerformanceController.kt
@@ -49,6 +49,31 @@ class PerformanceController(
         return CursoredResponse(null, performances)
     }
 
+    @Operation(
+        summary = "공연 목록 조회 v2",
+        description = "조건 없이 공연 목록을 조회합니다. 커서 기반 페이징을 지원합니다.",
+        responses = [
+            ApiResponse(responseCode = "200", description = "성공적으로 공연 목록을 조회함")
+        ]
+    )
+    @GetMapping("/v2")
+    fun getListV2(
+        @ParameterObject @ModelAttribute cursorInfoDto: CursorInfoDto
+    ): CursoredResponse<PerformanceSummarySearchResult> {
+        val performances = performanceService.search(
+            CursorInfoDto(cursorInfoDto.cursor, cursorInfoDto.limit + 1)
+        )
+
+        if (performances.size == cursorInfoDto.limit + 1) {
+            return CursoredResponse(
+                performances[cursorInfoDto.limit].uid,
+                performances.dropLast(1)
+            )
+        }
+
+        return CursoredResponse(null, performances)
+    }
+
 
     @Operation(
         summary = "공연 상세 정보 조회",

--- a/src/main/kotlin/com/flab/ticketing/performance/controller/PerformanceControllerV2.kt
+++ b/src/main/kotlin/com/flab/ticketing/performance/controller/PerformanceControllerV2.kt
@@ -1,0 +1,47 @@
+package com.flab.ticketing.performance.controller
+
+import com.flab.ticketing.common.dto.response.CursoredResponse
+import com.flab.ticketing.common.dto.service.CursorInfoDto
+import com.flab.ticketing.performance.dto.service.PerformanceSummarySearchResult
+import com.flab.ticketing.performance.service.PerformanceService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import org.springdoc.core.annotations.ParameterObject
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+
+@RestController
+@RequestMapping("/api/v2/performances")
+class PerformanceControllerV2(
+    private val performanceService: PerformanceService
+) {
+
+
+    @Operation(
+        summary = "공연 목록 조회 v2",
+        description = "조건 없이 공연 목록을 조회합니다. 커서 기반 페이징을 지원합니다.",
+        responses = [
+            ApiResponse(responseCode = "200", description = "성공적으로 공연 목록을 조회함")
+        ]
+    )
+    @GetMapping()
+    fun getListV2(
+        @ParameterObject @ModelAttribute cursorInfoDto: CursorInfoDto
+    ): CursoredResponse<PerformanceSummarySearchResult> {
+        val performances = performanceService.search(
+            CursorInfoDto(cursorInfoDto.cursor, cursorInfoDto.limit + 1)
+        )
+
+        if (performances.size == cursorInfoDto.limit + 1) {
+            return CursoredResponse(
+                performances[cursorInfoDto.limit].uid,
+                performances.dropLast(1)
+            )
+        }
+
+        return CursoredResponse(null, performances)
+    }
+}

--- a/src/main/kotlin/com/flab/ticketing/performance/dto/service/PerformanceStartEndDateResult.kt
+++ b/src/main/kotlin/com/flab/ticketing/performance/dto/service/PerformanceStartEndDateResult.kt
@@ -1,0 +1,9 @@
+package com.flab.ticketing.performance.dto.service
+
+import java.time.ZonedDateTime
+
+data class PerformanceStartEndDateResult(
+    val performanceId: Long,
+    val startDate: ZonedDateTime,
+    val endDate: ZonedDateTime
+)

--- a/src/main/kotlin/com/flab/ticketing/performance/dto/service/PerformanceSummarySearchResult.kt
+++ b/src/main/kotlin/com/flab/ticketing/performance/dto/service/PerformanceSummarySearchResult.kt
@@ -8,18 +8,18 @@ data class PerformanceSummarySearchResult(
     val image: String,
     val title: String,
     val regionName: String,
-    val startDate: LocalDate,
-    val endDate: LocalDate
+    val startDate: LocalDate?,
+    val endDate: LocalDate?
 ) {
     constructor(
         uid: String,
         image: String,
         title: String,
         regionName: String,
-        startDate: ZonedDateTime,
-        endDate: ZonedDateTime
+        startDate: ZonedDateTime?,
+        endDate: ZonedDateTime?
     ) : this(
-        uid, image, title, regionName, startDate.toLocalDate(), endDate.toLocalDate()
+        uid, image, title, regionName, startDate?.toLocalDate(), endDate?.toLocalDate()
     )
 
 }

--- a/src/main/kotlin/com/flab/ticketing/performance/entity/Performance.kt
+++ b/src/main/kotlin/com/flab/ticketing/performance/entity/Performance.kt
@@ -27,7 +27,10 @@ class Performance(
     val performancePlace: PerformancePlace,
 
     @OneToMany(mappedBy = "performance", fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
-    val performanceDateTime: MutableList<PerformanceDateTime> = mutableListOf()
+    val performanceDateTime: MutableList<PerformanceDateTime> = mutableListOf(),
+
+    val placeName: String,
+    val regionName: String
 ) : BaseEntity() {
 
     fun addDateTime(

--- a/src/main/kotlin/com/flab/ticketing/performance/repository/PerformanceDateRepository.kt
+++ b/src/main/kotlin/com/flab/ticketing/performance/repository/PerformanceDateRepository.kt
@@ -1,5 +1,6 @@
 package com.flab.ticketing.performance.repository
 
+import com.flab.ticketing.performance.dto.service.PerformanceStartEndDateResult
 import com.flab.ticketing.performance.entity.PerformanceDateTime
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.CrudRepository
@@ -20,4 +21,14 @@ interface PerformanceDateRepository : CrudRepository<PerformanceDateTime, Long> 
         @Param("performanceUid") performanceUid: String,
         @Param("dateUid") dateUid: String
     ): PerformanceDateTime?
+
+    @Query(
+        "SELECT new com.flab.ticketing.performance.dto.service.PerformanceStartEndDateResult(" +
+                "pd.performance.id, min(pd.showTime), max(pd.showTime)" +
+                ") " +
+                "from PerformanceDateTime pd " +
+                "where pd.performance.id in :performanceIdList " +
+                "group by pd.performance.id"
+    )
+    fun findStartAndEndDate(performanceIdList: List<Long>): List<PerformanceStartEndDateResult>
 }

--- a/src/main/kotlin/com/flab/ticketing/performance/repository/dsl/CustomPerformanceRepository.kt
+++ b/src/main/kotlin/com/flab/ticketing/performance/repository/dsl/CustomPerformanceRepository.kt
@@ -3,10 +3,16 @@ package com.flab.ticketing.performance.repository.dsl
 import com.flab.ticketing.common.dto.service.CursorInfoDto
 import com.flab.ticketing.performance.dto.request.PerformanceSearchConditions
 import com.flab.ticketing.performance.dto.service.PerformanceSummarySearchResult
+import com.flab.ticketing.performance.entity.Performance
 
 interface CustomPerformanceRepository {
     fun search(
         searchConditions: PerformanceSearchConditions,
         cursorInfoDto: CursorInfoDto
     ): List<PerformanceSummarySearchResult?>
+
+
+    fun search(
+        cursorInfoDto: CursorInfoDto
+    ): List<Performance>
 }

--- a/src/main/kotlin/com/flab/ticketing/performance/repository/dsl/CustomPerformanceRepositoryImpl.kt
+++ b/src/main/kotlin/com/flab/ticketing/performance/repository/dsl/CustomPerformanceRepositoryImpl.kt
@@ -20,7 +20,7 @@ class CustomPerformanceRepositoryImpl(
         cursorInfoDto: CursorInfoDto
     ): List<PerformanceSummarySearchResult?> {
 
-        val searchResult = kotlinJdslJpqlExecutor.findPage(PageRequest.of(0, cursorInfoDto.limit)) {
+        val searchResult = kotlinJdslJpqlExecutor.findAll(PageRequest.of(0, cursorInfoDto.limit)) {
 
             val cursorSubQuery = select<Long>(path(Performance::id))
                 .from(entity(Performance::class))
@@ -94,7 +94,37 @@ class CustomPerformanceRepositoryImpl(
                 )
         }
 
-        return searchResult.content
+        return searchResult
     }
 
+    override fun search(cursorInfoDto: CursorInfoDto): List<Performance> {
+        return kotlinJdslJpqlExecutor.findAll(PageRequest.of(0, cursorInfoDto.limit)) {
+            val cursorSubQuery = select<Long>(path(Performance::id))
+                .from(entity(Performance::class))
+                .where(
+                    path(Performance::uid).eq(cursorInfoDto.cursor)
+                ).asSubquery()
+
+            select(entity(Performance::class))
+                .from(
+                    entity(Performance::class),
+                    fetchJoin(entity(PerformancePlace::class)).on(
+                        path(Performance::performancePlace).eq(
+                            entity(PerformancePlace::class)
+                        )
+                    ),
+                    fetchJoin(entity(Region::class)).on(
+                        path(PerformancePlace::region).eq(
+                            entity(Region::class)
+                        )
+                    )
+                ).where(
+                    cursorInfoDto.cursor?.let {
+                        path(Performance::id).lessThanOrEqualTo(cursorSubQuery)
+                    }
+                ).orderBy(
+                    path(Performance::id).desc()
+                )
+        }.filterNotNull()
+    }
 }

--- a/src/main/kotlin/com/flab/ticketing/performance/repository/dsl/CustomPerformanceRepositoryImpl.kt
+++ b/src/main/kotlin/com/flab/ticketing/performance/repository/dsl/CustomPerformanceRepositoryImpl.kt
@@ -108,16 +108,8 @@ class CustomPerformanceRepositoryImpl(
             select(entity(Performance::class))
                 .from(
                     entity(Performance::class),
-                    fetchJoin(entity(PerformancePlace::class)).on(
-                        path(Performance::performancePlace).eq(
-                            entity(PerformancePlace::class)
-                        )
-                    ),
-                    fetchJoin(entity(Region::class)).on(
-                        path(PerformancePlace::region).eq(
-                            entity(Region::class)
-                        )
-                    )
+                    fetchJoin(Performance::performancePlace),
+                    fetchJoin(PerformancePlace::region)
                 ).where(
                     cursorInfoDto.cursor?.let {
                         path(Performance::id).lessThanOrEqualTo(cursorSubQuery)

--- a/src/main/kotlin/com/flab/ticketing/performance/repository/dsl/CustomPerformanceRepositoryImpl.kt
+++ b/src/main/kotlin/com/flab/ticketing/performance/repository/dsl/CustomPerformanceRepositoryImpl.kt
@@ -98,7 +98,7 @@ class CustomPerformanceRepositoryImpl(
     }
 
     override fun search(cursorInfoDto: CursorInfoDto): List<Performance> {
-        return kotlinJdslJpqlExecutor.findAll(PageRequest.of(0, cursorInfoDto.limit)) {
+        val t = kotlinJdslJpqlExecutor.findAll(PageRequest.of(0, cursorInfoDto.limit)) {
             val cursorSubQuery = select<Long>(path(Performance::id))
                 .from(entity(Performance::class))
                 .where(
@@ -107,9 +107,7 @@ class CustomPerformanceRepositoryImpl(
 
             select(entity(Performance::class))
                 .from(
-                    entity(Performance::class),
-                    fetchJoin(Performance::performancePlace),
-                    fetchJoin(PerformancePlace::region)
+                    entity(Performance::class)
                 ).where(
                     cursorInfoDto.cursor?.let {
                         path(Performance::id).lessThanOrEqualTo(cursorSubQuery)
@@ -117,6 +115,8 @@ class CustomPerformanceRepositoryImpl(
                 ).orderBy(
                     path(Performance::id).desc()
                 )
-        }.filterNotNull()
+        }
+
+        return t.filterNotNull()
     }
 }

--- a/src/main/kotlin/com/flab/ticketing/performance/repository/reader/PerformanceReader.kt
+++ b/src/main/kotlin/com/flab/ticketing/performance/repository/reader/PerformanceReader.kt
@@ -32,7 +32,7 @@ class PerformanceReader(
         return performanceRepository.search(searchConditions, cursorInfoDto).filterNotNull()
     }
 
-    fun findPerformanceEntityWithPlaceAndRegion(
+    fun findPerformanceEntityByCursor(
         cursorInfoDto: CursorInfoDto
     ): List<Performance> {
         return performanceRepository.search(cursorInfoDto)

--- a/src/main/kotlin/com/flab/ticketing/performance/repository/reader/PerformanceReader.kt
+++ b/src/main/kotlin/com/flab/ticketing/performance/repository/reader/PerformanceReader.kt
@@ -6,6 +6,7 @@ import com.flab.ticketing.common.exception.NotFoundException
 import com.flab.ticketing.performance.dto.request.PerformanceSearchConditions
 import com.flab.ticketing.performance.dto.service.PerformanceDateSummaryResult
 import com.flab.ticketing.performance.dto.service.PerformanceDetailSearchResult
+import com.flab.ticketing.performance.dto.service.PerformanceStartEndDateResult
 import com.flab.ticketing.performance.dto.service.PerformanceSummarySearchResult
 import com.flab.ticketing.performance.entity.Performance
 import com.flab.ticketing.performance.entity.PerformanceDateTime
@@ -29,6 +30,18 @@ class PerformanceReader(
         cursorInfoDto: CursorInfoDto
     ): List<PerformanceSummarySearchResult> {
         return performanceRepository.search(searchConditions, cursorInfoDto).filterNotNull()
+    }
+
+    fun findPerformanceEntityWithPlaceAndRegion(
+        cursorInfoDto: CursorInfoDto
+    ): List<Performance> {
+        return performanceRepository.search(cursorInfoDto)
+    }
+
+    fun findPerformanceStartAndEndDate(
+        performanceIdList: List<Long>
+    ): List<PerformanceStartEndDateResult> {
+        return performanceDateRepository.findStartAndEndDate(performanceIdList)
     }
 
     fun findPerformanceDetailDto(performanceUid: String): PerformanceDetailSearchResult {

--- a/src/main/kotlin/com/flab/ticketing/performance/service/PerformanceService.kt
+++ b/src/main/kotlin/com/flab/ticketing/performance/service/PerformanceService.kt
@@ -33,12 +33,14 @@ class PerformanceService(
         cursorInfoDto: CursorInfoDto
     ): List<PerformanceSummarySearchResult> {
         val performanceMap =
-            performanceReader.findPerformanceEntityWithPlaceAndRegion(cursorInfoDto).associateBy { it.id }
+            performanceReader.findPerformanceEntityWithPlaceAndRegion(cursorInfoDto)
+                .associateBy { it.id }
+                .toMap(LinkedHashMap())
 
         val startEndDateResultMap = performanceReader.findPerformanceStartAndEndDate(performanceMap.keys.toList())
             .associateBy { it.performanceId }
-        
-        return performanceMap.entries.toSortedSet { e1, e2 -> e2.key.compareTo(e1.key) }.map {
+
+        return performanceMap.entries.map {
             val startEndDateResult = startEndDateResultMap[it.key]
             val performance = it.value
             PerformanceSummarySearchResult(

--- a/src/main/kotlin/com/flab/ticketing/performance/service/PerformanceService.kt
+++ b/src/main/kotlin/com/flab/ticketing/performance/service/PerformanceService.kt
@@ -32,10 +32,9 @@ class PerformanceService(
     fun search(
         cursorInfoDto: CursorInfoDto
     ): List<PerformanceSummarySearchResult> {
-        val performanceMap =
-            performanceReader.findPerformanceEntityWithPlaceAndRegion(cursorInfoDto)
-                .associateBy { it.id }
-                .toMap(LinkedHashMap())
+        val performanceMap = performanceReader.findPerformanceEntityByCursor(cursorInfoDto)
+            .associateBy { it.id }
+            .toMap(LinkedHashMap())
 
         val startEndDateResultMap = performanceReader.findPerformanceStartAndEndDate(performanceMap.keys.toList())
             .associateBy { it.performanceId }
@@ -47,7 +46,7 @@ class PerformanceService(
                 performance.uid,
                 performance.image,
                 performance.name,
-                performance.performancePlace.region.name,
+                performance.regionName,
                 startEndDateResult?.startDate,
                 startEndDateResult?.endDate
             )

--- a/src/main/kotlin/com/flab/ticketing/performance/service/PerformanceService.kt
+++ b/src/main/kotlin/com/flab/ticketing/performance/service/PerformanceService.kt
@@ -29,6 +29,31 @@ class PerformanceService(
         return performanceReader.searchPerformanceSummaryDto(searchConditions, cursorInfoDto)
     }
 
+    fun search(
+        cursorInfoDto: CursorInfoDto
+    ): List<PerformanceSummarySearchResult> {
+        val performanceMap =
+            performanceReader.findPerformanceEntityWithPlaceAndRegion(cursorInfoDto).associateBy { it.id }
+
+        val startEndDateResultMap = performanceReader.findPerformanceStartAndEndDate(performanceMap.keys.toList())
+            .associateBy { it.performanceId }
+        
+        return performanceMap.entries.toSortedSet { e1, e2 -> e2.key.compareTo(e1.key) }.map {
+            val startEndDateResult = startEndDateResultMap[it.key]
+            val performance = it.value
+            PerformanceSummarySearchResult(
+                performance.uid,
+                performance.image,
+                performance.name,
+                performance.performancePlace.region.name,
+                startEndDateResult?.startDate,
+                startEndDateResult?.endDate
+            )
+        }
+
+    }
+
+
     fun searchDetail(uid: String): PerformanceDetailResponse {
         val performance = performanceReader.findPerformanceDetailDto(uid)
         val dateSummaryDtoList = performanceReader.findDateSummaryDto(uid)

--- a/src/test/kotlin/com/flab/ticketing/common/PerformanceTestDataGenerator.kt
+++ b/src/test/kotlin/com/flab/ticketing/common/PerformanceTestDataGenerator.kt
@@ -19,7 +19,11 @@ object PerformanceTestDataGenerator {
         return Region(generateUid("region"), name)
     }
 
-    fun createPerformancePlace(region: Region = createRegion(), name: String = " 공연장", numSeats: Int = 2): PerformancePlace {
+    fun createPerformancePlace(
+        region: Region = createRegion(),
+        name: String = " 공연장",
+        numSeats: Int = 2
+    ): PerformancePlace {
         val place = PerformancePlace(region, name)
         repeat(numSeats) {
             val row = it / 10 + 1
@@ -32,11 +36,11 @@ object PerformanceTestDataGenerator {
     fun createPerformance(
         place: PerformancePlace = createPerformancePlace(),
         name: String = "공연",
-        showTimes : List<ZonedDateTime>,
+        showTimes: List<ZonedDateTime>,
         price: Int = 10000,
-        image:String = "http://image.com/image/1",
+        image: String = "http://image.com/image/1",
         description: String = "공연 설명"
-    ) : Performance{
+    ): Performance {
 
         val performance = Performance(
             uid = generateUid("performance"),
@@ -44,10 +48,12 @@ object PerformanceTestDataGenerator {
             image = image,
             description = description,
             price = price,
-            performancePlace = place
+            performancePlace = place,
+            placeName = place.name,
+            regionName = place.region.name
         )
 
-        for(showTime in showTimes){
+        for (showTime in showTimes) {
             performance.addDateTime(generateUid("datetime"), showTime)
         }
 
@@ -67,7 +73,9 @@ object PerformanceTestDataGenerator {
             image = "https://example.com/image.jpg",
             description = "This is a test performance description",
             price = price,
-            performancePlace = place
+            performancePlace = place,
+            placeName = place.name,
+            regionName = place.region.name
         )
 
         repeat(numShowtimes) {
@@ -98,22 +106,23 @@ object PerformanceTestDataGenerator {
      */
     fun createPerformancesPriceIn(
         place: PerformancePlace,
-        priceIn : List<Int>,
+        priceIn: List<Int>,
         numShowtimes: Int = 2,
         showTimeStartDateTime: ZonedDateTime = INIT_PERFORMANCE_DATE
     ): MutableList<Performance> {
         val result = mutableListOf<Performance>()
-        for(price in priceIn){
+        for (price in priceIn) {
             result.add(
                 createPerformance(
                     place = place,
-                    numShowtimes= numShowtimes,
+                    numShowtimes = numShowtimes,
                     showTimeStartDateTime = showTimeStartDateTime,
-                    price = price)
+                    price = price
+                )
             )
         }
 
-        return result;
+        return result
     }
 
     /**
@@ -121,18 +130,19 @@ object PerformanceTestDataGenerator {
      */
     fun createPerformancesDatesIn(
         place: PerformancePlace = createPerformancePlace(),
-        dateIn : List<ZonedDateTime>,
+        dateIn: List<ZonedDateTime>,
         numShowtimes: Int = 2,
         price: Int = 10000
     ): MutableList<Performance> {
         val result = mutableListOf<Performance>()
-        for(date in dateIn){
+        for (date in dateIn) {
             result.add(
                 createPerformance(
                     place = place,
-                    numShowtimes= numShowtimes,
+                    numShowtimes = numShowtimes,
                     showTimeStartDateTime = date,
-                    price = price)
+                    price = price
+                )
             )
         }
 
@@ -144,18 +154,19 @@ object PerformanceTestDataGenerator {
      */
     fun createPerformancesInNames(
         place: PerformancePlace,
-        nameIn : List<String>,
+        nameIn: List<String>,
         numShowtimes: Int = 2,
         price: Int = 10000
-    ) : MutableList<Performance>{
+    ): MutableList<Performance> {
         val result = mutableListOf<Performance>()
-        for(name in nameIn){
+        for (name in nameIn) {
             result.add(
                 createPerformance(
                     place = place,
-                    numShowtimes= numShowtimes,
+                    numShowtimes = numShowtimes,
                     name = name,
-                    price = price)
+                    price = price
+                )
             )
 
         }
@@ -176,11 +187,11 @@ object PerformanceTestDataGenerator {
     }
 
 
-    fun reset(){
-        regionCounter = 0;
-        seatCounter = 0;
-        performanceCounter = 0;
-        datetimeCounter = 0;
+    fun reset() {
+        regionCounter = 0
+        seatCounter = 0
+        performanceCounter = 0
+        datetimeCounter = 0
 
     }
 

--- a/src/test/kotlin/com/flab/ticketing/common/UnitTest.kt
+++ b/src/test/kotlin/com/flab/ticketing/common/UnitTest.kt
@@ -1,5 +1,21 @@
 package com.flab.ticketing.common
 
+import com.flab.ticketing.common.entity.BaseEntity
 import io.kotest.core.spec.style.StringSpec
+import kotlin.reflect.KMutableProperty
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.jvm.isAccessible
 
-abstract class UnitTest : StringSpec()
+abstract class UnitTest : StringSpec() {
+
+    protected fun BaseEntity.setIdUsingReflection(newId: Long) {
+        val property = BaseEntity::class.memberProperties.find { it.name == "id" }
+        if (property != null && property is KMutableProperty<*>) {
+            property.isAccessible = true
+            property.setter.call(this, newId)
+        } else {
+            throw IllegalStateException("Cannot find mutable 'id' property in BaseEntity")
+        }
+    }
+
+}

--- a/src/test/kotlin/com/flab/ticketing/performance/integration/PerformanceSearchIntegrationTest.kt
+++ b/src/test/kotlin/com/flab/ticketing/performance/integration/PerformanceSearchIntegrationTest.kt
@@ -753,7 +753,7 @@ class PerformanceSearchIntegrationTest : IntegrationTest() {
 
             savePerformance(performances)
             `when`("사용자가 5개의 공연 정보를 조회할 시") {
-                val uri = "/api/performances/v2"
+                val uri = "/api/v2/performances"
                 val limit = 5
 
                 val mvcResult = mockMvc.perform(

--- a/src/test/kotlin/com/flab/ticketing/performance/repository/PerformanceRepositoryImplTest.kt
+++ b/src/test/kotlin/com/flab/ticketing/performance/repository/PerformanceRepositoryImplTest.kt
@@ -388,6 +388,43 @@ class PerformanceRepositoryImplTest(
             actual.performancePlace.id shouldBe expected.performancePlace.id
             actual.performancePlace.seats.map { it.uid } shouldContainAll expected.performancePlace.seats.map { it.uid }
         }
+
+        "Performance를 List로 조회할 수 있다. - v2" {
+            val givenPerformanceCnt = 5
+
+            val performances = PerformanceTestDataGenerator.createPerformanceGroupbyRegion(
+                performanceCount = givenPerformanceCnt
+            )
+
+            savePerformance(performances)
+
+            val cursorSize = 5
+            val actual = performanceRepository.search(CursorInfoDto(limit = cursorSize))
+
+            val expected = performances.sortedBy { it.id }.asReversed()
+
+            actual.size shouldBe cursorSize
+            actual shouldContainExactly expected
+        }
+
+        "Performance를 Cursor로 포함하여 List로 조회할 수 있다. - v2" {
+            var performances =
+                PerformanceTestDataGenerator.createPerformanceGroupbyRegion(performanceCount = 10)
+
+            savePerformance(performances)
+
+            performances = performances.sortedBy { it.id }.asReversed()
+
+            val limit = 5
+            val startIdx = 3
+            val actual = performanceRepository.search(
+                CursorInfoDto(performances[startIdx].uid, limit)
+            )
+
+            val expected = performances.subList(3, 8)
+
+            actual shouldContainExactly expected
+        }
     }
 
 

--- a/src/test/kotlin/com/flab/ticketing/performance/service/PerformanceServiceTest.kt
+++ b/src/test/kotlin/com/flab/ticketing/performance/service/PerformanceServiceTest.kt
@@ -197,8 +197,8 @@ class PerformanceServiceTest : UnitTest() {
             )
             performances.forEachIndexed { idx, it -> (it as BaseEntity).setIdUsingReflection(idx.toLong()) }
             performances = performances.reversed()
-            
-            every { performanceReader.findPerformanceEntityWithPlaceAndRegion(CursorInfoDto()) } returns performances
+
+            every { performanceReader.findPerformanceEntityByCursor(CursorInfoDto()) } returns performances
             every { performanceReader.findPerformanceStartAndEndDate(performances.map { it.id }) } returns createPerformanceStartAndEndDate(
                 performances
             )

--- a/src/test/kotlin/com/flab/ticketing/performance/service/PerformanceServiceTest.kt
+++ b/src/test/kotlin/com/flab/ticketing/performance/service/PerformanceServiceTest.kt
@@ -192,11 +192,12 @@ class PerformanceServiceTest : UnitTest() {
         }
 
         "Performance의 목록을 조회하고, 각 Performance의 StartDate와 EndDate를 조회해 매핑 한 후 반환할 수 있다." {
-            val performances = PerformanceTestDataGenerator.createPerformanceGroupbyRegion(
+            var performances = PerformanceTestDataGenerator.createPerformanceGroupbyRegion(
                 performanceCount = 6
             )
             performances.forEachIndexed { idx, it -> (it as BaseEntity).setIdUsingReflection(idx.toLong()) }
-
+            performances = performances.reversed()
+            
             every { performanceReader.findPerformanceEntityWithPlaceAndRegion(CursorInfoDto()) } returns performances
             every { performanceReader.findPerformanceStartAndEndDate(performances.map { it.id }) } returns createPerformanceStartAndEndDate(
                 performances

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -11,8 +11,8 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.H2Dialect
-  #        format_sql: true
-  #        show_sql: true
+        format_sql: true
+        show_sql: true
   mail:
     sender: noreply@minticketing.com
     host: localhost


### PR DESCRIPTION
## #️⃣연관된 이슈

> #83

## 📝작업 내용

> Performance 조회(검색 x) 로직을 개선하였습니다.
> - 불필요한 COUNT 쿼리가 실행되지 않도록 변경하였습니다.
> - GROUP BY JOIN문을 두개의 쿼리로 나누어 효율적인 조회가 이루어지도록 변경하였습니다.
> - indexsort를 사용하기 위해 반정규화를 진행하였습니다.

### 개선 결과
로컬에서 성능 테스트를 한 결과는 다음과 같습니다.
- 기존의 쿼리는 95%의 사용자가 11386.526917 ms(약 11.4초)에 응답을 받을 수 있었습니다.
- 불필요한 COUNT 쿼리를 제거하고 GROUP BY JOIN문을 IN 절로 변경한 결과 95%의 사용자가 15.342562 ms에 응답을 받을 수 있었습니다.(99.9% 개선)
- 반정규화 까지 적용한 결과 14.354615 ms에 95%의 사용자가 응답을 받을 수 있었습니다.(6.4% 추가 개선)

## 💬리뷰 요구사항(선택)
추가적으로 자세한 사항은 아래의 글에 자세하게 작성되어 있으니, 필요하면 참고해주시면 감사하겠습니다!
https://flannel-dill-7dc.notion.site/API-11cfc957389c805aa7f9e0a4d0c1480b?pvs=4
