### PR TITLE
Feature: Spring Cache 설정 추가 및 Performance 조회 API(v2)에 캐시 적용

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk-alpine
+FROM openjdk:17.0.1-jdk-slim
 
 # gradle 설정으로 plain jar 파일은 생성되지 않습니다.
 WORKDIR /app

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 
     implementation 'com.aventrix.jnanoid:jnanoid:2.0.0'
@@ -51,7 +54,7 @@ dependencies {
     implementation 'com.linecorp.kotlin-jdsl:jpql-render:3.5.1'
     implementation 'com.linecorp.kotlin-jdsl:spring-data-jpa-support:3.5.1'
 
-
+    implementation 'com.github.ben-manes.caffeine:caffeine'
     runtimeOnly "com.mysql:mysql-connector-j"
 //    runtimeOnly 'com.oracle.database.jdbc:ojdbc11'
 //    implementation 'com.oracle.database.security:osdt_cert'

--- a/src/main/kotlin/com/flab/ticketing/TicketingApplication.kt
+++ b/src/main/kotlin/com/flab/ticketing/TicketingApplication.kt
@@ -2,10 +2,12 @@ package com.flab.ticketing
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.cache.annotation.EnableCaching
 
 @SpringBootApplication
+@EnableCaching
 class TicketingApplication
 
 fun main(args: Array<String>) {
-	runApplication<TicketingApplication>(*args)
+    runApplication<TicketingApplication>(*args)
 }

--- a/src/main/kotlin/com/flab/ticketing/common/aop/utils/CustomSpringELParser.kt
+++ b/src/main/kotlin/com/flab/ticketing/common/aop/utils/CustomSpringELParser.kt
@@ -1,0 +1,21 @@
+package com.flab.ticketing.common.aop.utils
+
+
+import org.springframework.expression.ExpressionParser
+import org.springframework.expression.spel.standard.SpelExpressionParser
+import org.springframework.expression.spel.support.StandardEvaluationContext
+
+
+// 컬리의 https://helloworld.kurly.com/blog/distributed-redisson-lock/ 글을 참고하였습니다.
+object CustomSpringELParser {
+    fun getDynamicValue(parameterNames: Array<String>, args: Array<Any>, expression: String): Any? {
+        val parser: ExpressionParser = SpelExpressionParser()
+        val context = StandardEvaluationContext()
+
+        parameterNames.zip(args).forEach { (name, value) ->
+            context.setVariable(name, value)
+        }
+
+        return parser.parseExpression(expression).getValue(context, Any::class.java)
+    }
+}

--- a/src/main/kotlin/com/flab/ticketing/common/config/CacheConfig.kt
+++ b/src/main/kotlin/com/flab/ticketing/common/config/CacheConfig.kt
@@ -1,0 +1,120 @@
+package com.flab.ticketing.common.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.flab.ticketing.common.enums.CacheType
+import com.flab.ticketing.common.service.CustomCompositeCacheManager
+import com.github.benmanes.caffeine.cache.Caffeine
+import org.springframework.cache.CacheManager
+import org.springframework.cache.caffeine.CaffeineCache
+import org.springframework.cache.support.CompositeCacheManager
+import org.springframework.cache.support.SimpleCacheManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.RedisSerializationContext
+import org.springframework.data.redis.serializer.StringRedisSerializer
+import java.time.Duration
+
+
+@Configuration
+class CacheConfig(
+    private val redisConnectionFactory: RedisConnectionFactory
+) {
+
+    companion object {
+        const val COMPOSITE_CACHE_MANAGER_NAME = "compositeCacheManager"
+        const val LOCAL_CACHE_MANAGER_NAME = "localCacheManager"
+        const val GLOBAL_CACHE_MANAGER_NAME = "globalCacheManager"
+    }
+
+    @Primary
+    @Bean(COMPOSITE_CACHE_MANAGER_NAME)
+    fun compositeCacheManager(
+        localCacheManager: CacheManager,
+        globalCacheManager: CacheManager
+    ): CacheManager{
+        return CustomCompositeCacheManager(
+            listOf(localCacheManager, globalCacheManager)
+        )
+    }
+
+
+
+    @Bean(LOCAL_CACHE_MANAGER_NAME)
+    fun localCacheManager(): CacheManager {
+        val caches = CacheType.entries.map {
+            CaffeineCache(
+                it.cacheName,
+                Caffeine.newBuilder()
+                    .recordStats()
+                    .expireAfterWrite(it.localTtl)
+                    .maximumSize(20).build()
+            )
+        }
+
+        val cacheManager = SimpleCacheManager()
+        cacheManager.setCaches(caches)
+
+        return cacheManager
+    }
+
+    @Bean(GLOBAL_CACHE_MANAGER_NAME)
+    fun globalCacheManager(): CacheManager {
+        val cacheConfig = RediscacheConfiguration()
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+            .fromConnectionFactory(redisConnectionFactory)
+            .cacheDefaults(cacheConfig)
+            .withInitialCacheConfigurations(typedGlobalCacheConfiguration())
+            .build()
+
+    }
+
+
+    /**
+     *  Redis 캐시 설정 구성(Key : String, Value : JSON, TTL : 30m)
+     */
+    private fun RediscacheConfiguration(): RedisCacheConfiguration {
+        val keySerializer = RedisSerializationContext.SerializationPair.fromSerializer(StringRedisSerializer())
+        val valueSerializer = getValueSerializer()
+
+        val cacheConfig = RedisCacheConfiguration.defaultCacheConfig()
+            .serializeKeysWith(keySerializer)
+            .serializeValuesWith(valueSerializer)
+            .entryTtl(Duration.ofMinutes(30L))
+        return cacheConfig
+    }
+
+    private fun getValueSerializer(): RedisSerializationContext.SerializationPair<Any> {
+        // objectMapper가 모든 JSON을 직렬화/역직렬화하도록 설정
+        val typeValidator = BasicPolymorphicTypeValidator.builder()
+            .allowIfBaseType(Any::class.java)
+            .build()
+
+        // Jackson ObjectMapper 설정(DateTime 처리, Kotlin 처리)
+        val objectMapper = ObjectMapper().apply {
+            registerModule(JavaTimeModule())
+            registerModule(KotlinModule.Builder().build())
+            activateDefaultTyping(typeValidator, ObjectMapper.DefaultTyping.NON_FINAL)
+        }
+
+        val jsonSerializer = GenericJackson2JsonRedisSerializer(objectMapper)
+
+        return RedisSerializationContext.SerializationPair.fromSerializer(jsonSerializer)
+    }
+
+    private fun typedGlobalCacheConfiguration(): Map<String, RedisCacheConfiguration> {
+        return CacheType.values().associateBy(
+            keySelector = { it.cacheName },
+            valueTransform = { RediscacheConfiguration().entryTtl(it.globalTtl) }
+        )
+    }
+
+}

--- a/src/main/kotlin/com/flab/ticketing/common/enums/CacheType.kt
+++ b/src/main/kotlin/com/flab/ticketing/common/enums/CacheType.kt
@@ -1,0 +1,15 @@
+package com.flab.ticketing.common.enums
+
+import java.time.Duration
+
+
+enum class CacheType(val cacheName: String, val localTtl: Duration, val globalTtl: Duration) {
+    PRODUCT("product", Duration.ofMinutes(10), Duration.ofHours(1));
+
+
+    companion object {
+        const val PRODUCT_CACHE_NAME = "product"
+
+        fun getCacheNames() = values().map { it.cacheName }.toSet()
+    }
+}

--- a/src/main/kotlin/com/flab/ticketing/common/service/CustomCompositeCacheManager.kt
+++ b/src/main/kotlin/com/flab/ticketing/common/service/CustomCompositeCacheManager.kt
@@ -1,0 +1,68 @@
+package com.flab.ticketing.common.service
+
+import org.springframework.cache.Cache
+import org.springframework.cache.CacheManager
+import org.springframework.cache.support.CompositeCacheManager
+import java.util.concurrent.Callable
+
+class CustomCompositeCacheManager(
+    private val cacheManagers : List<CacheManager>
+) : CompositeCacheManager(){
+
+    init {
+        super.setCacheManagers(cacheManagers)
+    }
+
+    override fun getCache(name: String): Cache? {
+        val foundCaches = cacheManagers.mapNotNull { it.getCache(name) }
+
+        if (foundCaches.isEmpty()) {
+            return null
+        }
+
+        return CompositeCache(name, foundCaches)
+    }
+}
+
+internal class CompositeCache(
+    private val name: String,
+    private val caches: List<Cache>
+) : Cache {
+
+    override fun getName(): String = name
+
+    override fun getNativeCache(): Any = this
+
+    override fun get(key: Any): Cache.ValueWrapper? {
+        return caches.firstNotNullOfOrNull { it.get(key) }
+    }
+
+    override fun <T : Any?> get(key: Any, type: Class<T>?): T? {
+        return caches.firstNotNullOfOrNull { it.get(key, type) }
+    }
+
+    override fun <T : Any?> get(key: Any, valueLoader: Callable<T>): T? {
+        val value = caches.firstOrNull()?.get(key, valueLoader)
+        if (value != null) {
+            caches.drop(1).forEach { cache ->
+                cache.put(key, value)
+            }
+        }
+        return value
+    }
+
+    override fun put(key: Any, value: Any?) {
+        // 모든 캐시에 값을 저장
+        caches.forEach { it.put(key, value) }
+    }
+
+    override fun evict(key: Any) {
+        // 모든 캐시에서 해당 키의 값을 제거
+        caches.forEach { it.evict(key) }
+    }
+
+    override fun clear() {
+        // 모든 캐시를 초기화
+        caches.forEach { it.clear() }
+    }
+}

--- a/src/main/kotlin/com/flab/ticketing/order/repository/CartRepository.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/repository/CartRepository.kt
@@ -8,8 +8,7 @@ import org.springframework.stereotype.Repository
 
 @Repository
 interface CartRepository : JpaRepository<Cart, Long> {
-
-    fun save(cart: Cart)
+    
 
     @Query("SELECT c FROM Cart c WHERE c.user.uid = :userUid")
     fun findByUserUid(@Param("userUid") userUid: String): List<Cart>

--- a/src/main/kotlin/com/flab/ticketing/order/repository/proxy/ReservationCheck.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/repository/proxy/ReservationCheck.kt
@@ -1,0 +1,6 @@
+package com.flab.ticketing.order.repository.proxy
+
+annotation class ReservationCheck(
+    val key: String,
+    val value: String
+)

--- a/src/main/kotlin/com/flab/ticketing/order/repository/proxy/ReservationCheckProxy.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/repository/proxy/ReservationCheckProxy.kt
@@ -1,0 +1,89 @@
+package com.flab.ticketing.order.repository.proxy
+
+import com.flab.ticketing.common.aop.utils.CustomSpringELParser
+import com.flab.ticketing.common.aop.utils.CustomSpringELParser.getDynamicValue
+import com.flab.ticketing.common.exception.CommonErrorInfos
+import com.flab.ticketing.common.exception.DuplicatedException
+import com.flab.ticketing.common.exception.InternalServerException
+import com.flab.ticketing.order.entity.Cart
+import com.flab.ticketing.order.exception.OrderErrorInfos
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.reflect.MethodSignature
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Component
+import java.time.Duration
+
+
+@Aspect
+@Component
+class ReservationCheckProxy(
+    private val redisTemplate: RedisTemplate<String, String>
+
+) {
+    private val LOCK_PREFIX = "lock:"
+    private val LOCK_TIMEOUT_MILLIS = Duration.ofMillis(30L * 60_000L) // 30분
+
+
+    @Around("@annotation(com.flab.ticketing.order.repository.proxy.ReservationCheck)")
+    fun acquireLock(joinPoint: ProceedingJoinPoint): Any? {
+        val (key, value) = extractKVFromCart(joinPoint)
+        acquireLockOrThrows(key, value)
+
+        return joinPoint.proceed()
+    }
+
+
+    @Around("@annotation(com.flab.ticketing.order.repository.proxy.ReservationRelease)")
+    fun releaseLock(joinPoint: ProceedingJoinPoint): Any? {
+        val keyList = extractKeyListFromCartList(joinPoint)
+
+        redisTemplate.delete(keyList)
+        return joinPoint.proceed()
+    }
+
+    private fun acquireLockOrThrows(key: String, value: String) {
+        val result = redisTemplate.opsForValue()
+            .setIfAbsent(key, value, LOCK_TIMEOUT_MILLIS)!!
+
+        if (!result) {
+            throw DuplicatedException(OrderErrorInfos.ALREADY_RESERVED)
+        }
+    }
+
+
+    private fun extractKVFromCart(joinPoint: ProceedingJoinPoint): Pair<String, String> {
+        val signature = joinPoint.signature as MethodSignature
+        val method = signature.method
+        val annotation = method.getAnnotation(ReservationCheck::class.java)
+
+
+        val key = "${LOCK_PREFIX}${getDynamicValue(signature.parameterNames, joinPoint.args, annotation.key)}"
+        val value = getDynamicValue(signature.parameterNames, joinPoint.args, annotation.value).toString()
+
+        return Pair(key, value)
+    }
+
+    private fun extractKeyListFromCartList(joinPoint: ProceedingJoinPoint): List<String> {
+        val signature = joinPoint.signature as MethodSignature
+        val method = signature.method
+        val annotation = method.getAnnotation(ReservationRelease::class.java)
+
+        val carts = joinPoint.args
+            .firstOrNull { it is List<*> && it.all { item -> item is Cart } }
+            ?.let { it as List<Cart> }
+            ?: throw InternalServerException(CommonErrorInfos.SERVICE_ERROR)
+
+        return carts.map { cart ->
+            val key = getDynamicValue(
+                arrayOf("cart"),
+                arrayOf(cart),
+                annotation.key
+            )
+            "${LOCK_PREFIX}$key"
+        }
+    }
+
+
+}

--- a/src/main/kotlin/com/flab/ticketing/order/repository/proxy/ReservationRelease.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/repository/proxy/ReservationRelease.kt
@@ -1,0 +1,5 @@
+package com.flab.ticketing.order.repository.proxy
+
+annotation class ReservationRelease(
+    val key: String
+)

--- a/src/main/kotlin/com/flab/ticketing/order/repository/writer/CartWriter.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/repository/writer/CartWriter.kt
@@ -3,6 +3,8 @@ package com.flab.ticketing.order.repository.writer
 import com.flab.ticketing.common.aop.Logging
 import com.flab.ticketing.order.entity.Cart
 import com.flab.ticketing.order.repository.CartRepository
+import com.flab.ticketing.order.repository.proxy.ReservationCheck
+import com.flab.ticketing.order.repository.proxy.ReservationRelease
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 
@@ -14,14 +16,18 @@ class CartWriter(
     private val cartRepository: CartRepository
 ) {
 
+
+    @ReservationCheck(
+        key = "#cart.seat.uid + '_' + #cart.performanceDateTime.uid",
+        value = "#cart.user.uid"
+    )
     fun save(cart: Cart) {
         cartRepository.save(cart)
     }
 
-    fun saveAll(carts: List<Cart>) {
-        cartRepository.saveAll(carts)
-    }
-
+    @ReservationRelease(
+        key = "#cart.seat.uid + '_' + #cart.performanceDateTime.uid",
+    )
     fun deleteAll(carts: List<Cart>) {
         cartRepository.deleteAll(carts)
     }

--- a/src/main/kotlin/com/flab/ticketing/order/repository/writer/CartWriter.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/repository/writer/CartWriter.kt
@@ -18,7 +18,7 @@ class CartWriter(
 
 
     @ReservationCheck(
-        key = "#cart.seat.uid + '_' + #cart.performanceDateTime.uid",
+        key = "'cart_save_' + #cart.seat.uid + '_' + #cart.performanceDateTime.uid",
         value = "#cart.user.uid"
     )
     fun save(cart: Cart) {
@@ -26,7 +26,7 @@ class CartWriter(
     }
 
     @ReservationRelease(
-        key = "#cart.seat.uid + '_' + #cart.performanceDateTime.uid",
+        key = "'cart_save_' + #cart.seat.uid + '_' + #cart.performanceDateTime.uid",
     )
     fun deleteAll(carts: List<Cart>) {
         cartRepository.deleteAll(carts)

--- a/src/main/kotlin/com/flab/ticketing/performance/repository/PerformanceDateRepository.kt
+++ b/src/main/kotlin/com/flab/ticketing/performance/repository/PerformanceDateRepository.kt
@@ -1,5 +1,6 @@
 package com.flab.ticketing.performance.repository
 
+import com.flab.ticketing.performance.dto.service.PerformanceDateSummaryResult
 import com.flab.ticketing.performance.dto.service.PerformanceStartEndDateResult
 import com.flab.ticketing.performance.entity.PerformanceDateTime
 import org.springframework.data.jpa.repository.Query
@@ -31,4 +32,15 @@ interface PerformanceDateRepository : CrudRepository<PerformanceDateTime, Long> 
                 "group by pd.performance.id"
     )
     fun findStartAndEndDate(performanceIdList: List<Long>): List<PerformanceStartEndDateResult>
+
+    @Query(
+        "SELECT new com.flab.ticketing.performance.dto.service.PerformanceDateSummaryResult(pd.uid, pd.showTime, count(ss), count(rs.seat), count(c.seat)) FROM PerformanceDateTime pd " +
+                "JOIN PerformancePlace pp ON pd.performance.performancePlace = pp " +
+                "JOIN pp.seats ss " +
+                "LEFT JOIN Reservation rs ON ss = rs.seat " +
+                "LEFT JOIN Cart c ON ss = c.seat " +
+                "WHERE pd.performance.id = :performanceId " +
+                "GROUP BY pd.id"
+    )
+    fun getDateInfo(@Param("performanceId") performanceId: Long): List<PerformanceDateSummaryResult>
 }

--- a/src/main/kotlin/com/flab/ticketing/performance/repository/PerformanceRepository.kt
+++ b/src/main/kotlin/com/flab/ticketing/performance/repository/PerformanceRepository.kt
@@ -1,7 +1,5 @@
 package com.flab.ticketing.performance.repository
 
-import com.flab.ticketing.performance.dto.service.PerformanceDateSummaryResult
-import com.flab.ticketing.performance.dto.service.PerformanceDetailSearchResult
 import com.flab.ticketing.performance.entity.Performance
 import com.flab.ticketing.performance.repository.dsl.CustomPerformanceRepository
 import org.springframework.data.jpa.repository.Query
@@ -16,26 +14,7 @@ interface PerformanceRepository : CustomPerformanceRepository,
     fun deleteAll()
 
 
-    @Query(
-        "SELECT new com.flab.ticketing.performance.dto.service.PerformanceDetailSearchResult(p.uid, p.image, p.name, r.name, pp.name, p.price, p.description) FROM Performance p " +
-                "JOIN p.performancePlace pp " +
-                "JOIN pp.region r " +
-                "WHERE p.uid = :uid"
-    )
-    fun findByUid(@Param("uid") uid: String): PerformanceDetailSearchResult?
-
-
-    @Query(
-        "SELECT new com.flab.ticketing.performance.dto.service.PerformanceDateSummaryResult(pd.uid, pd.showTime, count(ss), count(rs.seat), count(c.seat)) FROM Performance p " +
-                "JOIN p.performanceDateTime pd " +
-                "JOIN p.performancePlace pp " +
-                "JOIN pp.seats ss " +
-                "LEFT JOIN Reservation rs ON ss = rs.seat " +
-                "LEFT JOIN Cart c ON ss = c.seat " +
-                "WHERE p.uid = :uid " +
-                "GROUP BY pd.uid"
-    )
-    fun getDateInfo(@Param("uid") performanceUid: String): List<PerformanceDateSummaryResult>
+    fun findByUid(@Param("uid") uid: String): Performance?
 
 
     @Query(

--- a/src/main/kotlin/com/flab/ticketing/performance/repository/reader/PerformanceReader.kt
+++ b/src/main/kotlin/com/flab/ticketing/performance/repository/reader/PerformanceReader.kt
@@ -5,7 +5,6 @@ import com.flab.ticketing.common.dto.service.CursorInfoDto
 import com.flab.ticketing.common.exception.NotFoundException
 import com.flab.ticketing.performance.dto.request.PerformanceSearchConditions
 import com.flab.ticketing.performance.dto.service.PerformanceDateSummaryResult
-import com.flab.ticketing.performance.dto.service.PerformanceDetailSearchResult
 import com.flab.ticketing.performance.dto.service.PerformanceStartEndDateResult
 import com.flab.ticketing.performance.dto.service.PerformanceSummarySearchResult
 import com.flab.ticketing.performance.entity.Performance
@@ -44,7 +43,7 @@ class PerformanceReader(
         return performanceDateRepository.findStartAndEndDate(performanceIdList)
     }
 
-    fun findPerformanceDetailDto(performanceUid: String): PerformanceDetailSearchResult {
+    fun findPerformanceDetailDto(performanceUid: String): Performance {
         return performanceRepository.findByUid(performanceUid)
             ?: throw NotFoundException(PerformanceErrorInfos.PERFORMANCE_NOT_FOUND)
     }
@@ -56,8 +55,8 @@ class PerformanceReader(
             )
     }
 
-    fun findDateSummaryDto(performanceUid: String): List<PerformanceDateSummaryResult> {
-        return performanceRepository.getDateInfo(performanceUid)
+    fun findDateSummaryDto(performanceId: Long): List<PerformanceDateSummaryResult> {
+        return performanceDateRepository.getDateInfo(performanceId)
     }
 
     fun findDateEntityByUid(performanceUid: String, dateUid: String): PerformanceDateTime {

--- a/src/main/kotlin/com/flab/ticketing/performance/service/PerformanceService.kt
+++ b/src/main/kotlin/com/flab/ticketing/performance/service/PerformanceService.kt
@@ -39,7 +39,7 @@ class PerformanceService(
             Cacheable(
                 cacheManager = CacheConfig.COMPOSITE_CACHE_MANAGER_NAME,
                 cacheNames = [CacheType.PRODUCT_CACHE_NAME],
-                key = "(#cursorInfoDto.cursor ?: 'first_page') + '_' + #cursorInfoDto.limit"
+                key = "'performance_' + (#cursorInfoDto.cursor ?: 'first_page') + '_' + #cursorInfoDto.limit"
             )
         ]
     )

--- a/src/main/kotlin/com/flab/ticketing/performance/service/PerformanceService.kt
+++ b/src/main/kotlin/com/flab/ticketing/performance/service/PerformanceService.kt
@@ -1,6 +1,8 @@
 package com.flab.ticketing.performance.service
 
+import com.flab.ticketing.common.config.CacheConfig
 import com.flab.ticketing.common.dto.service.CursorInfoDto
+import com.flab.ticketing.common.enums.CacheType
 import com.flab.ticketing.order.repository.reader.CartReader
 import com.flab.ticketing.order.repository.reader.ReservationReader
 import com.flab.ticketing.performance.dto.request.PerformanceSearchConditions
@@ -10,6 +12,8 @@ import com.flab.ticketing.performance.dto.service.PerformanceDateSummaryResult
 import com.flab.ticketing.performance.dto.service.PerformanceSummarySearchResult
 import com.flab.ticketing.performance.entity.PerformancePlaceSeat
 import com.flab.ticketing.performance.repository.reader.PerformanceReader
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.cache.annotation.Caching
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -29,6 +33,16 @@ class PerformanceService(
         return performanceReader.searchPerformanceSummaryDto(searchConditions, cursorInfoDto)
     }
 
+
+    @Caching(
+        cacheable = [
+            Cacheable(
+                cacheManager = CacheConfig.COMPOSITE_CACHE_MANAGER_NAME,
+                cacheNames = [CacheType.PRODUCT_CACHE_NAME],
+                key = "(#cursorInfoDto.cursor ?: 'first_page') + '_' + #cursorInfoDto.limit"
+            )
+        ]
+    )
     fun search(
         cursorInfoDto: CursorInfoDto
     ): List<PerformanceSummarySearchResult> {
@@ -57,13 +71,13 @@ class PerformanceService(
 
     fun searchDetail(uid: String): PerformanceDetailResponse {
         val performance = performanceReader.findPerformanceDetailDto(uid)
-        val dateSummaryDtoList = performanceReader.findDateSummaryDto(uid)
+        val dateSummaryDtoList = performanceReader.findDateSummaryDto(performance.id)
         val dateInfo = convertDateDtoToDateInfo(dateSummaryDtoList)
 
         return PerformanceDetailResponse(
             performance.uid,
             performance.image,
-            performance.title,
+            performance.name,
             performance.regionName,
             performance.placeName,
             performance.price,

--- a/src/test/kotlin/com/flab/ticketing/common/MockServerUtils.kt
+++ b/src/test/kotlin/com/flab/ticketing/common/MockServerUtils.kt
@@ -1,7 +1,5 @@
 package com.flab.ticketing.common
 
-import jakarta.annotation.PostConstruct
-import jakarta.annotation.PreDestroy
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.springframework.boot.test.context.TestComponent
@@ -12,10 +10,10 @@ import org.springframework.http.MediaType
 @TestComponent
 class MockServerUtils {
 
-    private val mockWebServer = MockWebServer()
+    private lateinit var mockWebServer: MockWebServer
 
-    @PostConstruct
     fun runServer() {
+        mockWebServer = MockWebServer()
         mockWebServer.start(port = 2024)
     }
 
@@ -28,10 +26,10 @@ class MockServerUtils {
             MockResponse()
                 .setResponseCode(responseStatus.value())
                 .setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
-                .setBody(body))
+                .setBody(body)
+        )
     }
 
-    @PreDestroy
     fun shutDown() {
         mockWebServer.shutdown()
     }

--- a/src/test/kotlin/com/flab/ticketing/order/service/ReservationServiceLockTest.kt
+++ b/src/test/kotlin/com/flab/ticketing/order/service/ReservationServiceLockTest.kt
@@ -22,9 +22,6 @@ import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.cache.Cache
-import org.springframework.cache.CacheManager
-import org.springframework.cache.get
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.data.redis.core.ValueOperations
 
@@ -88,7 +85,7 @@ class ReservationServiceLockTest : IntegrationTest() {
 
         }
 
-        given("특정 공연 정보가 존재할 때 - Caching 추가 확인"){
+        given("특정 공연 정보가 존재할 때 - Caching 추가 확인") {
             val performance = PerformanceTestDataGenerator.createPerformance()
             val user = UserTestDataGenerator.createUser()
             val performanceDateTime = performance.performanceDateTime[0]
@@ -105,8 +102,8 @@ class ReservationServiceLockTest : IntegrationTest() {
             `when`("사용자가 이미 예약된 좌석에 대해 Redis에 Lock 정보가 남아있다면") {
                 reservationService.reserve(user.uid, performance.uid, performanceDateTime.uid, seat.uid)
 
-                then("Cache를 추가해 저장한다."){
-                    val key = "lock:${seat.uid}_${performanceDateTime.uid}"
+                then("Cache를 추가해 저장한다.") {
+                    val key = "lock:cart_save_${seat.uid}_${performanceDateTime.uid}"
                     val value = user.uid
                     verify(exactly = 1) { mockRedisOperation.setIfAbsent(key, value, any()) }
                 }

--- a/src/test/kotlin/com/flab/ticketing/order/service/ReservationServiceLockTest.kt
+++ b/src/test/kotlin/com/flab/ticketing/order/service/ReservationServiceLockTest.kt
@@ -1,0 +1,140 @@
+package com.flab.ticketing.order.service
+
+import com.flab.ticketing.common.IntegrationTest
+import com.flab.ticketing.common.PerformanceTestDataGenerator
+import com.flab.ticketing.common.UserTestDataGenerator
+import com.flab.ticketing.common.exception.DuplicatedException
+import com.flab.ticketing.order.entity.Cart
+import com.flab.ticketing.order.repository.CartRepository
+import com.flab.ticketing.performance.entity.Performance
+import com.flab.ticketing.performance.repository.PerformancePlaceRepository
+import com.flab.ticketing.performance.repository.PerformanceRepository
+import com.flab.ticketing.performance.repository.RegionRepository
+import com.flab.ticketing.user.repository.UserRepository
+import com.ninjasquad.springmockk.MockkBean
+import com.ninjasquad.springmockk.SpykBean
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.cache.Cache
+import org.springframework.cache.CacheManager
+import org.springframework.cache.get
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.ValueOperations
+
+class ReservationServiceLockTest : IntegrationTest() {
+
+    @Autowired
+    private lateinit var reservationService: ReservationService
+
+    @MockkBean
+    private lateinit var cartRepository: CartRepository
+
+    @SpykBean
+    private lateinit var redisTemplate: RedisTemplate<String, String>
+
+    @Autowired
+    private lateinit var regionRepository: RegionRepository
+
+    @Autowired
+    private lateinit var placeRepository: PerformancePlaceRepository
+
+    @Autowired
+    private lateinit var performanceRepository: PerformanceRepository
+
+    @Autowired
+    private lateinit var userRepository: UserRepository
+
+    init {
+
+        given("특정 공연 정보가 존재할 때") {
+            val performance = PerformanceTestDataGenerator.createPerformance()
+            val user = UserTestDataGenerator.createUser()
+            val performanceDateTime = performance.performanceDateTime[0]
+            val seat = performance.performancePlace.seats[0]
+
+            every { cartRepository.save(any()) } returns Cart("uid", seat, performanceDateTime, user)
+            userRepository.save(user)
+            savePerformance(listOf(performance))
+
+
+            // warm-up
+            reservationService.reserve(user.uid, performance.uid, performanceDateTime.uid, seat.uid)
+
+
+            `when`("사용자가 이미 예약된 좌석에 대해 Redis에 Lock 정보가 남아있다면") {
+                val user2 = UserTestDataGenerator.createUser(uid = "uid", email = "e@e.com")
+
+                userRepository.save(user2)
+                then("DB에 SAVE 요청을 보내지 않고 DuplicatedException을 throw한다.") {
+                    shouldThrow<DuplicatedException> {
+                        reservationService.reserve(
+                            user2.uid,
+                            performance.uid,
+                            performanceDateTime.uid,
+                            seat.uid
+                        )
+                    }
+
+                    verify(exactly = 1) { cartRepository.save(any()) }
+                }
+            }
+
+        }
+
+        given("특정 공연 정보가 존재할 때 - Caching 추가 확인"){
+            val performance = PerformanceTestDataGenerator.createPerformance()
+            val user = UserTestDataGenerator.createUser()
+            val performanceDateTime = performance.performanceDateTime[0]
+            val seat = performance.performancePlace.seats[0]
+            val mockRedisOperation = mockk<ValueOperations<String, String>>()
+
+
+            every { redisTemplate.opsForValue() } returns mockRedisOperation
+            every { mockRedisOperation.setIfAbsent(any(), any(), any()) } returns true
+            every { cartRepository.save(any()) } returns Cart("uid", seat, performanceDateTime, user)
+            userRepository.save(user)
+            savePerformance(listOf(performance))
+
+            `when`("사용자가 이미 예약된 좌석에 대해 Redis에 Lock 정보가 남아있다면") {
+                reservationService.reserve(user.uid, performance.uid, performanceDateTime.uid, seat.uid)
+
+                then("Cache를 추가해 저장한다."){
+                    val key = "lock:${seat.uid}_${performanceDateTime.uid}"
+                    val value = user.uid
+                    verify(exactly = 1) { mockRedisOperation.setIfAbsent(key, value, any()) }
+                }
+            }
+
+        }
+    }
+
+
+    override suspend fun afterEach(testCase: TestCase, result: TestResult) {
+        super.afterEach(testCase, result)
+        withContext(Dispatchers.IO) {
+            userRepository.deleteAll()
+            performanceRepository.deleteAll()
+            placeRepository.deleteAll()
+            regionRepository.deleteAll()
+        }
+
+
+    }
+
+    private fun savePerformance(performances: List<Performance>) {
+        regionRepository.save(performances[0].performancePlace.region)
+        placeRepository.save(performances[0].performancePlace)
+
+        performances.forEach {
+            performanceRepository.save(it)
+        }
+    }
+
+}

--- a/src/test/kotlin/com/flab/ticketing/performance/repository/PerformanceRepositoryImplTest.kt
+++ b/src/test/kotlin/com/flab/ticketing/performance/repository/PerformanceRepositoryImplTest.kt
@@ -11,6 +11,7 @@ import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.equals.shouldBeEqual
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import org.springframework.beans.factory.annotation.Autowired
@@ -28,6 +29,9 @@ class PerformanceRepositoryImplTest(
 
     @Autowired
     private lateinit var placeRepository: PerformancePlaceRepository
+
+    @Autowired
+    private lateinit var performanceDateRepository: PerformanceDateRepository
 
     init {
 
@@ -296,17 +300,11 @@ class PerformanceRepositoryImplTest(
 
             savePerformance(listOf(performance))
 
-            val (uid, image, title, regionName, placeName, price, description) = performanceRepository.findByUid(
+            val findPerformance = performanceRepository.findByUid(
                 performance.uid
             )!!
 
-            uid shouldBe performance.uid
-            image shouldBe performance.image
-            title shouldBe performance.name
-            regionName shouldBe performance.performancePlace.region.name
-            placeName shouldBe performance.performancePlace.name
-            price shouldBe performance.price
-            description shouldBe performance.description
+            findPerformance shouldBeEqual performance
         }
 
         "Performance를 UID로 검색할 시 UID에 해당하는 정보만 나온다." {
@@ -354,7 +352,7 @@ class PerformanceRepositoryImplTest(
                 )
             }
 
-            val actual = performanceRepository.getDateInfo(performance.uid)
+            val actual = performanceDateRepository.getDateInfo(performance.id)
 
             actual shouldContainAll expected
         }
@@ -368,7 +366,7 @@ class PerformanceRepositoryImplTest(
 
             savePerformance(performances)
 
-            val actual = performanceRepository.getDateInfo(performances[0].uid)
+            val actual = performanceDateRepository.getDateInfo(performances[0].id)
             actual.size shouldBe datePerPerformance
             actual.map { it.uid } shouldContainAll performances[0].performanceDateTime.map { it.uid }
         }

--- a/src/test/kotlin/com/flab/ticketing/performance/service/PerformanceServiceCacheTest.kt
+++ b/src/test/kotlin/com/flab/ticketing/performance/service/PerformanceServiceCacheTest.kt
@@ -1,0 +1,91 @@
+package com.flab.ticketing.performance.service
+
+import com.flab.ticketing.common.IntegrationTest
+import com.flab.ticketing.common.PerformanceTestDataGenerator
+import com.flab.ticketing.common.config.CacheConfig
+import com.flab.ticketing.common.dto.service.CursorInfoDto
+import com.flab.ticketing.common.enums.CacheType
+import com.flab.ticketing.performance.dto.service.PerformanceStartEndDateResult
+import com.flab.ticketing.performance.repository.reader.PerformanceReader
+import com.ninjasquad.springmockk.MockkBean
+import com.ninjasquad.springmockk.SpykBean
+import io.kotest.matchers.collections.shouldContainExactly
+import io.mockk.every
+import io.mockk.verify
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.cache.CacheManager
+
+class PerformanceServiceCacheTest : IntegrationTest() {
+
+    @MockkBean
+    private lateinit var performanceReader: PerformanceReader
+
+    @Autowired
+    private lateinit var performanceService: PerformanceService
+
+    @SpykBean(name = CacheConfig.LOCAL_CACHE_MANAGER_NAME)
+    private lateinit var localCacheManager: CacheManager
+
+
+    @SpykBean(name = CacheConfig.GLOBAL_CACHE_MANAGER_NAME)
+    private lateinit var globalCacheManager: CacheManager
+
+    init {
+        given("search 메서드가 Cache가 적용되었을 때") {
+            val performances =
+                PerformanceTestDataGenerator.createPerformanceGroupbyRegion(performanceCount = 5)
+
+            every { performanceReader.findPerformanceEntityByCursor(any()) } returns performances
+            every { performanceReader.findPerformanceStartAndEndDate(any()) } returns performances.map { performance ->
+                PerformanceStartEndDateResult(
+                    performance.id,
+                    performance.performanceDateTime.minOf { it.showTime },
+                    performance.performanceDateTime.maxOf { it.showTime })
+            }
+
+            `when`("동일한 파라미터로 2번 이상 검색시") {
+
+                val cursorDto = CursorInfoDto(limit = 5)
+
+                val searchResult1 = performanceService.search(cursorDto)
+                val searchResult2 = performanceService.search(cursorDto)
+
+                then("한번은 캐싱되어 호출된다.") {
+                    verify(exactly = 1) { performanceReader.findPerformanceEntityByCursor(any()) }
+                    verify(exactly = 1) { performanceReader.findPerformanceStartAndEndDate(any()) }
+                    searchResult1 shouldContainExactly searchResult2
+                }
+            }
+        }
+
+
+        given("search 메서드가 Cache가 적용되었을 때 - CompositeCacheManger 테스트"){
+            val performances =
+                PerformanceTestDataGenerator.createPerformanceGroupbyRegion(performanceCount = 5)
+
+            every { performanceReader.findPerformanceEntityByCursor(any()) } returns performances
+            every { performanceReader.findPerformanceStartAndEndDate(any()) } returns performances.map { performance ->
+                PerformanceStartEndDateResult(
+                    performance.id,
+                    performance.performanceDateTime.minOf { it.showTime },
+                    performance.performanceDateTime.maxOf { it.showTime })
+            }
+
+            `when`("동일한 파라미터로 2번 이상 검색시") {
+
+                val cursorDto = CursorInfoDto(limit = 5)
+
+                performanceService.search(cursorDto)
+                performanceService.search(cursorDto)
+
+                then("두개의 CacheManager에서 모두 값을 조회한다.") {
+                    verify(exactly = 2) { localCacheManager.getCache(CacheType.PRODUCT_CACHE_NAME) }
+                    verify(exactly = 2) { globalCacheManager.getCache(CacheType.PRODUCT_CACHE_NAME) }
+                }
+            }
+
+        }
+
+    }
+
+}

--- a/src/test/kotlin/com/flab/ticketing/performance/service/PerformanceServiceTest.kt
+++ b/src/test/kotlin/com/flab/ticketing/performance/service/PerformanceServiceTest.kt
@@ -10,7 +10,6 @@ import com.flab.ticketing.order.repository.reader.ReservationReader
 import com.flab.ticketing.performance.dto.response.PerformanceDateDetailResponse
 import com.flab.ticketing.performance.dto.response.PerformanceDetailResponse
 import com.flab.ticketing.performance.dto.service.PerformanceDateSummaryResult
-import com.flab.ticketing.performance.dto.service.PerformanceDetailSearchResult
 import com.flab.ticketing.performance.dto.service.PerformanceStartEndDateResult
 import com.flab.ticketing.performance.dto.service.PerformanceSummarySearchResult
 import com.flab.ticketing.performance.entity.Performance
@@ -44,15 +43,6 @@ class PerformanceServiceTest : UnitTest() {
             val reservedSeats = 2L
             val cartedSeats = 3L
 
-            val givenPerformanceInfo = PerformanceDetailSearchResult(
-                uid = performance.uid,
-                image = performance.image,
-                title = performance.name,
-                regionName = performance.performancePlace.region.name,
-                placeName = performance.performancePlace.name,
-                price = performance.price,
-                description = performance.description
-            )
 
             val givenDateInfos = performance.performanceDateTime.map {
                 PerformanceDateSummaryResult(
@@ -64,8 +54,8 @@ class PerformanceServiceTest : UnitTest() {
                 )
             }
 
-            every { performanceReader.findPerformanceDetailDto(performance.uid) } returns givenPerformanceInfo
-            every { performanceReader.findDateSummaryDto(performance.uid) } returns givenDateInfos
+            every { performanceReader.findPerformanceDetailDto(performance.uid) } returns performance
+            every { performanceReader.findDateSummaryDto(performance.id) } returns givenDateInfos
 
             val (actualUid, actualImage, actualTitle, actualRegion, actualPlace, actualPrice, actualDesc, actualDateInfo) = performanceService.searchDetail(
                 performance.uid


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #96 

## 📝작업 내용

> Spring Cache를 사용해 Performance API(v2)에서 사용되는 서비스 메서드에 캐시를 적용하였습니다. key의 예시는 다음과 같습니다.
> - 1페이지 : first_page_${limit}
> - 2페이지 이후 : ${cursor}_${limit}
> 추가적으로 Spring Actuator에 Cache Metric을 수집하도록 등록해주어야 하는데, 이미 자동구성으로 등록(CacheMetricsRegistrarConfiguration)되어 있어서 등록할 필요가 없음을 확인했습니다.
