### PR TITLE
fix : 함수 종속 GROUP BY 오류 문제 수정

### DIFF
--- a/src/main/kotlin/com/flab/ticketing/performance/repository/PerformanceDateRepository.kt
+++ b/src/main/kotlin/com/flab/ticketing/performance/repository/PerformanceDateRepository.kt
@@ -1,5 +1,6 @@
 package com.flab.ticketing.performance.repository
 
+import com.flab.ticketing.performance.dto.service.PerformanceDateSummaryResult
 import com.flab.ticketing.performance.dto.service.PerformanceStartEndDateResult
 import com.flab.ticketing.performance.entity.PerformanceDateTime
 import org.springframework.data.jpa.repository.Query
@@ -31,4 +32,15 @@ interface PerformanceDateRepository : CrudRepository<PerformanceDateTime, Long> 
                 "group by pd.performance.id"
     )
     fun findStartAndEndDate(performanceIdList: List<Long>): List<PerformanceStartEndDateResult>
+
+    @Query(
+        "SELECT new com.flab.ticketing.performance.dto.service.PerformanceDateSummaryResult(pd.uid, pd.showTime, count(ss), count(rs.seat), count(c.seat)) FROM PerformanceDateTime pd " +
+                "JOIN PerformancePlace pp ON pd.performance.performancePlace = pp " +
+                "JOIN pp.seats ss " +
+                "LEFT JOIN Reservation rs ON ss = rs.seat " +
+                "LEFT JOIN Cart c ON ss = c.seat " +
+                "WHERE pd.performance.id = :performanceId " +
+                "GROUP BY pd.id"
+    )
+    fun getDateInfo(@Param("performanceId") performanceId: Long): List<PerformanceDateSummaryResult>
 }

--- a/src/main/kotlin/com/flab/ticketing/performance/repository/PerformanceRepository.kt
+++ b/src/main/kotlin/com/flab/ticketing/performance/repository/PerformanceRepository.kt
@@ -1,7 +1,5 @@
 package com.flab.ticketing.performance.repository
 
-import com.flab.ticketing.performance.dto.service.PerformanceDateSummaryResult
-import com.flab.ticketing.performance.dto.service.PerformanceDetailSearchResult
 import com.flab.ticketing.performance.entity.Performance
 import com.flab.ticketing.performance.repository.dsl.CustomPerformanceRepository
 import org.springframework.data.jpa.repository.Query
@@ -16,26 +14,7 @@ interface PerformanceRepository : CustomPerformanceRepository,
     fun deleteAll()
 
 
-    @Query(
-        "SELECT new com.flab.ticketing.performance.dto.service.PerformanceDetailSearchResult(p.uid, p.image, p.name, r.name, pp.name, p.price, p.description) FROM Performance p " +
-                "JOIN p.performancePlace pp " +
-                "JOIN pp.region r " +
-                "WHERE p.uid = :uid"
-    )
-    fun findByUid(@Param("uid") uid: String): PerformanceDetailSearchResult?
-
-
-    @Query(
-        "SELECT new com.flab.ticketing.performance.dto.service.PerformanceDateSummaryResult(pd.uid, pd.showTime, count(ss), count(rs.seat), count(c.seat)) FROM Performance p " +
-                "JOIN p.performanceDateTime pd " +
-                "JOIN p.performancePlace pp " +
-                "JOIN pp.seats ss " +
-                "LEFT JOIN Reservation rs ON ss = rs.seat " +
-                "LEFT JOIN Cart c ON ss = c.seat " +
-                "WHERE p.uid = :uid " +
-                "GROUP BY pd.uid"
-    )
-    fun getDateInfo(@Param("uid") performanceUid: String): List<PerformanceDateSummaryResult>
+    fun findByUid(@Param("uid") uid: String): Performance?
 
 
     @Query(

--- a/src/main/kotlin/com/flab/ticketing/performance/repository/reader/PerformanceReader.kt
+++ b/src/main/kotlin/com/flab/ticketing/performance/repository/reader/PerformanceReader.kt
@@ -5,7 +5,6 @@ import com.flab.ticketing.common.dto.service.CursorInfoDto
 import com.flab.ticketing.common.exception.NotFoundException
 import com.flab.ticketing.performance.dto.request.PerformanceSearchConditions
 import com.flab.ticketing.performance.dto.service.PerformanceDateSummaryResult
-import com.flab.ticketing.performance.dto.service.PerformanceDetailSearchResult
 import com.flab.ticketing.performance.dto.service.PerformanceStartEndDateResult
 import com.flab.ticketing.performance.dto.service.PerformanceSummarySearchResult
 import com.flab.ticketing.performance.entity.Performance
@@ -44,7 +43,7 @@ class PerformanceReader(
         return performanceDateRepository.findStartAndEndDate(performanceIdList)
     }
 
-    fun findPerformanceDetailDto(performanceUid: String): PerformanceDetailSearchResult {
+    fun findPerformanceDetailDto(performanceUid: String): Performance {
         return performanceRepository.findByUid(performanceUid)
             ?: throw NotFoundException(PerformanceErrorInfos.PERFORMANCE_NOT_FOUND)
     }
@@ -56,8 +55,8 @@ class PerformanceReader(
             )
     }
 
-    fun findDateSummaryDto(performanceUid: String): List<PerformanceDateSummaryResult> {
-        return performanceRepository.getDateInfo(performanceUid)
+    fun findDateSummaryDto(performanceId: Long): List<PerformanceDateSummaryResult> {
+        return performanceDateRepository.getDateInfo(performanceId)
     }
 
     fun findDateEntityByUid(performanceUid: String, dateUid: String): PerformanceDateTime {

--- a/src/main/kotlin/com/flab/ticketing/performance/service/PerformanceService.kt
+++ b/src/main/kotlin/com/flab/ticketing/performance/service/PerformanceService.kt
@@ -63,13 +63,13 @@ class PerformanceService(
 
     fun searchDetail(uid: String): PerformanceDetailResponse {
         val performance = performanceReader.findPerformanceDetailDto(uid)
-        val dateSummaryDtoList = performanceReader.findDateSummaryDto(uid)
+        val dateSummaryDtoList = performanceReader.findDateSummaryDto(performance.id)
         val dateInfo = convertDateDtoToDateInfo(dateSummaryDtoList)
 
         return PerformanceDetailResponse(
             performance.uid,
             performance.image,
-            performance.title,
+            performance.name,
             performance.regionName,
             performance.placeName,
             performance.price,

--- a/src/test/kotlin/com/flab/ticketing/performance/repository/PerformanceRepositoryImplTest.kt
+++ b/src/test/kotlin/com/flab/ticketing/performance/repository/PerformanceRepositoryImplTest.kt
@@ -11,6 +11,7 @@ import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.equals.shouldBeEqual
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import org.springframework.beans.factory.annotation.Autowired
@@ -28,6 +29,9 @@ class PerformanceRepositoryImplTest(
 
     @Autowired
     private lateinit var placeRepository: PerformancePlaceRepository
+
+    @Autowired
+    private lateinit var performanceDateRepository: PerformanceDateRepository
 
     init {
 
@@ -296,17 +300,11 @@ class PerformanceRepositoryImplTest(
 
             savePerformance(listOf(performance))
 
-            val (uid, image, title, regionName, placeName, price, description) = performanceRepository.findByUid(
+            val findPerformance = performanceRepository.findByUid(
                 performance.uid
             )!!
 
-            uid shouldBe performance.uid
-            image shouldBe performance.image
-            title shouldBe performance.name
-            regionName shouldBe performance.performancePlace.region.name
-            placeName shouldBe performance.performancePlace.name
-            price shouldBe performance.price
-            description shouldBe performance.description
+            findPerformance shouldBeEqual performance
         }
 
         "Performance를 UID로 검색할 시 UID에 해당하는 정보만 나온다." {
@@ -354,7 +352,7 @@ class PerformanceRepositoryImplTest(
                 )
             }
 
-            val actual = performanceRepository.getDateInfo(performance.uid)
+            val actual = performanceDateRepository.getDateInfo(performance.id)
 
             actual shouldContainAll expected
         }
@@ -368,7 +366,7 @@ class PerformanceRepositoryImplTest(
 
             savePerformance(performances)
 
-            val actual = performanceRepository.getDateInfo(performances[0].uid)
+            val actual = performanceDateRepository.getDateInfo(performances[0].id)
             actual.size shouldBe datePerPerformance
             actual.map { it.uid } shouldContainAll performances[0].performanceDateTime.map { it.uid }
         }

--- a/src/test/kotlin/com/flab/ticketing/performance/service/PerformanceServiceTest.kt
+++ b/src/test/kotlin/com/flab/ticketing/performance/service/PerformanceServiceTest.kt
@@ -10,7 +10,6 @@ import com.flab.ticketing.order.repository.reader.ReservationReader
 import com.flab.ticketing.performance.dto.response.PerformanceDateDetailResponse
 import com.flab.ticketing.performance.dto.response.PerformanceDetailResponse
 import com.flab.ticketing.performance.dto.service.PerformanceDateSummaryResult
-import com.flab.ticketing.performance.dto.service.PerformanceDetailSearchResult
 import com.flab.ticketing.performance.dto.service.PerformanceStartEndDateResult
 import com.flab.ticketing.performance.dto.service.PerformanceSummarySearchResult
 import com.flab.ticketing.performance.entity.Performance
@@ -44,15 +43,6 @@ class PerformanceServiceTest : UnitTest() {
             val reservedSeats = 2L
             val cartedSeats = 3L
 
-            val givenPerformanceInfo = PerformanceDetailSearchResult(
-                uid = performance.uid,
-                image = performance.image,
-                title = performance.name,
-                regionName = performance.performancePlace.region.name,
-                placeName = performance.performancePlace.name,
-                price = performance.price,
-                description = performance.description
-            )
 
             val givenDateInfos = performance.performanceDateTime.map {
                 PerformanceDateSummaryResult(
@@ -64,8 +54,8 @@ class PerformanceServiceTest : UnitTest() {
                 )
             }
 
-            every { performanceReader.findPerformanceDetailDto(performance.uid) } returns givenPerformanceInfo
-            every { performanceReader.findDateSummaryDto(performance.uid) } returns givenDateInfos
+            every { performanceReader.findPerformanceDetailDto(performance.uid) } returns performance
+            every { performanceReader.findDateSummaryDto(performance.id) } returns givenDateInfos
 
             val (actualUid, actualImage, actualTitle, actualRegion, actualPlace, actualPrice, actualDesc, actualDateInfo) = performanceService.searchDetail(
                 performance.uid


### PR DESCRIPTION
## #️⃣연관된 이슈

> #100 

## 📝작업 내용

> Performance 상세 검색 시 performance_datetime의 `show_time`이 기존의 group by 기준 필드인 `uid`에 함수 종속이 맺어져있지 않다고 MySQL이 인식을 해서 나타난 오류였습니다. 따라서 group by 기준을 uid에서 id로 변경하니 정상 동작하였습니다.


## 💬리뷰 요구사항(선택)

>추가적으로 JOIN절이 너무 많이 걸려있어서 성능 최적화가 필요하진 않을까 쿼리 분석을 해보았는데, 효율적으로 동작 되는 것으로 보여서 쿼리 최적화는 진행하지 않았습니다.

| id | select_type | table | partitions | type | possible_keys | key | key_len | ref | rows | filtered | Extra |
|----|-------------|--------|------------|------|---------------|-----|---------|-----|------|-----------|--------|
| 1 | SIMPLE | p | NULL | const | PRIMARY,FK888vq870okmpvmvj6wg3kqt3k | PRIMARY | 8 | const | 1 | 100.00 | NULL |
| 1 | SIMPLE | pp | NULL | const | PRIMARY | PRIMARY | 8 | const | 1 | 100.00 | Using index |
| 1 | SIMPLE | pdt | NULL | ref | PRIMARY,uk_performance_datetimes_uid,UK56xnm5oig3ynq2nc9i2jgvdrw,FK5mqulsthehqtjvn37qabaggeg | FK5mqulsthehqtjvn37qabaggeg | 8 | const | 9 | 100.00 | NULL |
| 1 | SIMPLE | s | NULL | ref | FKo5puc5o4k0i0dkt78s7ku9sbt | FKo5puc5o4k0i0dkt78s7ku9sbt | 8 | const | 216 | 100.00 | Using where; Using index |
| 1 | SIMPLE | r | NULL | ref | FK8kigjuiy3c607t4t8rd1numub | FK8kigjuiy3c607t4t8rd1numub | 9 | ticketing.s1_0.id | 1 | 100.00 | Using index |
| 1 | SIMPLE | c | NULL | ref | ux_seat_uid_date_uid | ux_seat_uid_date_uid | 9 | ticketing.s1_0.id | 1 | 100.00 | Using index |
