### PR TITLE
Feature: 중복 체크 로직 추상화

### DIFF
--- a/src/main/kotlin/com/flab/ticketing/common/aop/DuplicatedCheck.kt
+++ b/src/main/kotlin/com/flab/ticketing/common/aop/DuplicatedCheck.kt
@@ -1,0 +1,5 @@
+package com.flab.ticketing.common.aop
+
+annotation class DuplicatedCheck(
+    val key: String
+)

--- a/src/main/kotlin/com/flab/ticketing/common/aop/ReleaseDuplicateCheck.kt
+++ b/src/main/kotlin/com/flab/ticketing/common/aop/ReleaseDuplicateCheck.kt
@@ -1,0 +1,5 @@
+package com.flab.ticketing.common.aop
+
+annotation class ReleaseDuplicateCheck(
+    val key: String
+)

--- a/src/main/kotlin/com/flab/ticketing/order/repository/proxy/ReservationCheck.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/repository/proxy/ReservationCheck.kt
@@ -1,6 +1,0 @@
-package com.flab.ticketing.order.repository.proxy
-
-annotation class ReservationCheck(
-    val key: String,
-    val value: String
-)

--- a/src/main/kotlin/com/flab/ticketing/order/repository/proxy/ReservationRelease.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/repository/proxy/ReservationRelease.kt
@@ -1,5 +1,0 @@
-package com.flab.ticketing.order.repository.proxy
-
-annotation class ReservationRelease(
-    val key: String
-)

--- a/src/main/kotlin/com/flab/ticketing/order/repository/writer/CartWriter.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/repository/writer/CartWriter.kt
@@ -1,10 +1,10 @@
 package com.flab.ticketing.order.repository.writer
 
+import com.flab.ticketing.common.aop.DuplicatedCheck
 import com.flab.ticketing.common.aop.Logging
+import com.flab.ticketing.common.aop.ReleaseDuplicateCheck
 import com.flab.ticketing.order.entity.Cart
 import com.flab.ticketing.order.repository.CartRepository
-import com.flab.ticketing.order.repository.proxy.ReservationCheck
-import com.flab.ticketing.order.repository.proxy.ReservationRelease
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 
@@ -17,16 +17,16 @@ class CartWriter(
 ) {
 
 
-    @ReservationCheck(
+    @DuplicatedCheck(
         key = "'cart_save_' + #cart.seat.uid + '_' + #cart.performanceDateTime.uid",
-        value = "#cart.user.uid"
     )
     fun save(cart: Cart) {
         cartRepository.save(cart)
     }
 
-    @ReservationRelease(
-        key = "'cart_save_' + #cart.seat.uid + '_' + #cart.performanceDateTime.uid",
+
+    @ReleaseDuplicateCheck(
+        key = "'cart_save_' + #carts.![seat.uid + '_' + performanceDateTime.uid]",
     )
     fun deleteAll(carts: List<Cart>) {
         cartRepository.deleteAll(carts)

--- a/src/test/kotlin/com/flab/ticketing/order/service/ReservationServiceDuplicateCheckTest.kt
+++ b/src/test/kotlin/com/flab/ticketing/order/service/ReservationServiceDuplicateCheckTest.kt
@@ -6,6 +6,7 @@ import com.flab.ticketing.common.UserTestDataGenerator
 import com.flab.ticketing.common.exception.DuplicatedException
 import com.flab.ticketing.order.entity.Cart
 import com.flab.ticketing.order.repository.CartRepository
+import com.flab.ticketing.order.repository.writer.CartWriter
 import com.flab.ticketing.performance.entity.Performance
 import com.flab.ticketing.performance.repository.PerformancePlaceRepository
 import com.flab.ticketing.performance.repository.PerformanceRepository
@@ -16,16 +17,14 @@ import com.ninjasquad.springmockk.SpykBean
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.verify
+import io.mockk.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.data.redis.core.ValueOperations
 
-class ReservationServiceLockTest : IntegrationTest() {
+class ReservationServiceDuplicateCheckTest : IntegrationTest() {
 
     @Autowired
     private lateinit var reservationService: ReservationService
@@ -47,6 +46,9 @@ class ReservationServiceLockTest : IntegrationTest() {
 
     @Autowired
     private lateinit var userRepository: UserRepository
+
+    @Autowired
+    private lateinit var cartWriter: CartWriter
 
     init {
 
@@ -104,11 +106,42 @@ class ReservationServiceLockTest : IntegrationTest() {
 
                 then("Cache를 추가해 저장한다.") {
                     val key = "lock:cart_save_${seat.uid}_${performanceDateTime.uid}"
-                    val value = user.uid
-                    verify(exactly = 1) { mockRedisOperation.setIfAbsent(key, value, any()) }
+                    verify(exactly = 1) { mockRedisOperation.setIfAbsent(key, any(), any()) }
+
                 }
             }
 
+        }
+
+        given("특정 사용자가 예약을 했을 때") {
+            val performance = PerformanceTestDataGenerator.createPerformance()
+            val user = UserTestDataGenerator.createUser()
+            val performanceDateTime = performance.performanceDateTime[0]
+            val seat = performance.performancePlace.seats[0]
+            val mockRedisOperation = mockk<ValueOperations<String, String>>()
+            val cart = Cart("uid", seat, performanceDateTime, user)
+
+
+            every { redisTemplate.opsForValue() } returns mockRedisOperation
+            every { mockRedisOperation.setIfAbsent(any(), any(), any()) } returns true
+            every { cartRepository.save(any()) } returns cart
+            every { cartRepository.deleteAll(any()) } just Runs
+
+            userRepository.save(user)
+            savePerformance(listOf(performance))
+
+
+            // Warm - up
+            reservationService.reserve(user.uid, performance.uid, performanceDateTime.uid, seat.uid)
+            `when`("예약을 취소하거나 결제할 시") {
+                cartWriter.deleteAll(listOf(cart))
+
+                then("Lock 정보를 제거한다.") {
+                    verify(exactly = 1) { redisTemplate.delete(listOf("lock:cart_save_${seat.uid}_${performanceDateTime.uid}")) }
+
+                }
+
+            }
         }
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #104 

## 📝작업 내용

> 이전에 했던 작업에 이어 중복 체크를 추상화하였습니다.
> @DuplicateCheck와 @ReleaseDuplicationCheck 두가지 어노테이션을 제공하며, 전자는 데드락 문제가 발생하기 때문에 단건만 등록, 후자는 List로 한꺼번에 제거가 가능하도록 설정했습니다.

