### PR TITLE
Feature: 주문 API 수정

### DIFF
--- a/src/main/kotlin/com/flab/ticketing/common/utils/Base64Utils.kt
+++ b/src/main/kotlin/com/flab/ticketing/common/utils/Base64Utils.kt
@@ -1,0 +1,14 @@
+package com.flab.ticketing.common.utils
+
+import java.util.*
+
+
+object Base64Utils {
+    fun encode(input: String): String {
+        return Base64.getEncoder().encodeToString(input.toByteArray())
+    }
+
+    fun decode(input: String): String {
+        return String(Base64.getDecoder().decode(input))
+    }
+}

--- a/src/main/kotlin/com/flab/ticketing/order/controller/OrderController.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/controller/OrderController.kt
@@ -47,7 +47,7 @@ class OrderController(
         @LoginUser userInfo: AuthenticatedUserDto,
         @RequestBody orderInfoRequest: OrderInfoRequest
     ): OrderInfoResponse {
-        return orderService.saveRequestedOrderInfo(userInfo, orderInfoRequest)
+        return orderService.createOrderMetaData(userInfo, orderInfoRequest)
     }
 
 

--- a/src/main/kotlin/com/flab/ticketing/order/dto/request/OrderConfirmRequest.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/dto/request/OrderConfirmRequest.kt
@@ -1,8 +1,21 @@
 package com.flab.ticketing.order.dto.request
 
+import com.flab.ticketing.order.entity.Order
+
 data class OrderConfirmRequest(
     val paymentType: String,
     val orderId: String,
     val paymentKey: String,
     val amount: Int
-)
+) {
+
+    fun ofPayments(): Order.Payment {
+        return Order.Payment(
+            amount,
+            paymentType,
+            paymentKey
+        )
+    }
+
+
+}

--- a/src/main/kotlin/com/flab/ticketing/order/dto/request/OrderInfoRequest.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/dto/request/OrderInfoRequest.kt
@@ -1,6 +1,5 @@
 package com.flab.ticketing.order.dto.request
 
 data class OrderInfoRequest(
-    val payType: String,
-    val carts: List<String>
+    val cartUidList: List<String>
 )

--- a/src/main/kotlin/com/flab/ticketing/order/dto/response/OrderInfoResponse.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/dto/response/OrderInfoResponse.kt
@@ -1,24 +1,17 @@
 package com.flab.ticketing.order.dto.response
 
-import com.flab.ticketing.order.entity.Order
-import com.flab.ticketing.user.entity.User
+import com.flab.ticketing.order.entity.OrderMetaData
 
 data class OrderInfoResponse(
-    val orderName: String,
     val orderId: String,
-    val customerEmail: String,
-    val customerName: String,
     val amount: Int
 ) {
 
     companion object {
-        fun of(user: User, order: Order): OrderInfoResponse {
+        fun of(orderMetaData: OrderMetaData): OrderInfoResponse {
             return OrderInfoResponse(
-                order.name,
-                order.uid,
-                user.email,
-                user.nickname,
-                order.payment.totalPrice
+                orderMetaData.orderId,
+                orderMetaData.amount
             )
         }
     }

--- a/src/main/kotlin/com/flab/ticketing/order/entity/Order.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/entity/Order.kt
@@ -25,6 +25,36 @@ class Order(
     var status: OrderStatus = OrderStatus.COMPLETED
 
 ) : BaseEntity() {
+
+    companion object {
+
+        fun of(
+            metaData: OrderMetaData,
+            user: User,
+            payment: Payment,
+            orderStatus: OrderStatus = OrderStatus.COMPLETED,
+            carts: List<Cart> = listOf()
+        ): Order {
+            val order = Order(
+                metaData.orderId,
+                user,
+                payment,
+                orderStatus
+            )
+            carts.map {
+                Reservation(
+                    it.performanceDateTime,
+                    it.seat,
+                    order
+                )
+            }.forEach { order.addReservation(it) }
+
+            return order
+        }
+
+    }
+
+
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "order", cascade = [CascadeType.ALL])
     val reservations: MutableList<Reservation> = mutableListOf()
 

--- a/src/main/kotlin/com/flab/ticketing/order/entity/Order.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/entity/Order.kt
@@ -22,14 +22,14 @@ class Order(
     val payment: Payment,
 
     @Enumerated(EnumType.STRING)
-    var status: OrderStatus = OrderStatus.REQUESTED
+    var status: OrderStatus = OrderStatus.COMPLETED
 
 ) : BaseEntity() {
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "order", cascade = [CascadeType.ALL])
     val reservations: MutableList<Reservation> = mutableListOf()
 
     var name: String = generateName()
-    
+
     fun addReservation(reservation: Reservation) {
         reservations.add(reservation)
         name = generateName()
@@ -65,11 +65,11 @@ class Order(
     class Payment(
         val totalPrice: Int,
         val paymentMethod: String,
-        var paymentKey: String? = null
+        var paymentKey: String
     )
 
 
     enum class OrderStatus {
-        REQUESTED, PENDING, COMPLETED, FAILED, CANCELED
+        COMPLETED, CANCELED
     }
 }

--- a/src/main/kotlin/com/flab/ticketing/order/entity/OrderMetaData.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/entity/OrderMetaData.kt
@@ -1,0 +1,15 @@
+package com.flab.ticketing.order.entity
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.redis.core.RedisHash
+
+
+@RedisHash(value = "order_meta_data", timeToLive = 30 * 60)
+class OrderMetaData(
+
+    @Id
+    val orderId: String,
+    val amount: Int,
+    val cartUidList: List<String>,
+    val userUid: String
+)

--- a/src/main/kotlin/com/flab/ticketing/order/repository/CartRepository.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/repository/CartRepository.kt
@@ -1,6 +1,7 @@
 package com.flab.ticketing.order.repository
 
 import com.flab.ticketing.order.entity.Cart
+import com.flab.ticketing.user.entity.User
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
@@ -8,7 +9,7 @@ import org.springframework.stereotype.Repository
 
 @Repository
 interface CartRepository : JpaRepository<Cart, Long> {
-    
+
 
     @Query("SELECT c FROM Cart c WHERE c.user.uid = :userUid")
     fun findByUserUid(@Param("userUid") userUid: String): List<Cart>
@@ -25,6 +26,12 @@ interface CartRepository : JpaRepository<Cart, Long> {
     )
     fun findSeatUidByDateUidAndPlaceIn(@Param("dateUid") dateUid: String, @Param("placeId") placeId: Long): List<String>
 
-    @Query("SELECT c FROM Cart c JOIN FETCH c.performanceDateTime pd JOIN FETCH pd.performance JOIN FETCH c.seat WHERE c.uid IN :uidList")
-    fun findByUidListInJoinWith(@Param("uidList") uidList: List<String>): List<Cart>
+    @Query(
+        "SELECT c FROM Cart c " +
+                "JOIN FETCH c.performanceDateTime pd " +
+                "JOIN FETCH pd.performance " +
+                "JOIN FETCH c.seat " +
+                "WHERE c.uid IN :uidList AND c.user = :user"
+    )
+    fun findByUidListInJoinWith(@Param("uidList") uidList: List<String>, @Param("user") user: User): List<Cart>
 }

--- a/src/main/kotlin/com/flab/ticketing/order/repository/OrderMetaDataRepository.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/repository/OrderMetaDataRepository.kt
@@ -1,0 +1,6 @@
+package com.flab.ticketing.order.repository
+
+import com.flab.ticketing.order.entity.OrderMetaData
+import org.springframework.data.repository.CrudRepository
+
+interface OrderMetaDataRepository : CrudRepository<OrderMetaData, String> 

--- a/src/main/kotlin/com/flab/ticketing/order/repository/reader/CartReader.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/repository/reader/CartReader.kt
@@ -3,6 +3,7 @@ package com.flab.ticketing.order.repository.reader
 import com.flab.ticketing.common.aop.Logging
 import com.flab.ticketing.order.entity.Cart
 import com.flab.ticketing.order.repository.CartRepository
+import com.flab.ticketing.user.entity.User
 import org.springframework.stereotype.Component
 
 
@@ -20,7 +21,7 @@ class CartReader(
         return cartRepository.findSeatUidByDateUidAndPlaceIn(performanceDateTimeUid, placeId)
     }
 
-    fun findByUidList(uidList: List<String>): List<Cart> {
-        return cartRepository.findByUidListInJoinWith(uidList)
+    fun findByUidList(uidList: List<String>, user: User): List<Cart> {
+        return cartRepository.findByUidListInJoinWith(uidList, user)
     }
 }

--- a/src/main/kotlin/com/flab/ticketing/order/repository/reader/OrderReader.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/repository/reader/OrderReader.kt
@@ -5,14 +5,17 @@ import com.flab.ticketing.common.dto.service.CursorInfoDto
 import com.flab.ticketing.common.exception.NotFoundException
 import com.flab.ticketing.order.dto.request.OrderSearchConditions
 import com.flab.ticketing.order.entity.Order
+import com.flab.ticketing.order.entity.OrderMetaData
 import com.flab.ticketing.order.exception.OrderErrorInfos
+import com.flab.ticketing.order.repository.OrderMetaDataRepository
 import com.flab.ticketing.order.repository.OrderRepository
 import org.springframework.stereotype.Component
 
 @Component
 @Logging
 class OrderReader(
-    private val orderRepository: OrderRepository
+    private val orderRepository: OrderRepository,
+    private val orderMetaDataRepository: OrderMetaDataRepository
 ) {
 
     fun findByUid(uid: String): Order {
@@ -25,5 +28,12 @@ class OrderReader(
         cursorInfo: CursorInfoDto
     ): List<Order> {
         return orderRepository.findByUser(userUid, cursorInfo, searchConditions).filterNotNull()
+    }
+
+    fun findMetaData(
+        orderId: String
+    ): OrderMetaData {
+        return orderMetaDataRepository.findById(orderId)
+            .orElseThrow { throw NotFoundException(OrderErrorInfos.ORDER_INFO_NOT_FOUND) }!!
     }
 }

--- a/src/main/kotlin/com/flab/ticketing/order/repository/writer/OrderWriter.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/repository/writer/OrderWriter.kt
@@ -26,4 +26,8 @@ class OrderWriter(
     fun delete(order: Order) {
         orderRepository.delete(order)
     }
+
+    fun deleteMetaData(orderMetaData: OrderMetaData) {
+        orderMetaDataRepository.delete(orderMetaData)
+    }
 }

--- a/src/main/kotlin/com/flab/ticketing/order/repository/writer/OrderWriter.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/repository/writer/OrderWriter.kt
@@ -2,6 +2,8 @@ package com.flab.ticketing.order.repository.writer
 
 import com.flab.ticketing.common.aop.Logging
 import com.flab.ticketing.order.entity.Order
+import com.flab.ticketing.order.entity.OrderMetaData
+import com.flab.ticketing.order.repository.OrderMetaDataRepository
 import com.flab.ticketing.order.repository.OrderRepository
 import org.springframework.stereotype.Component
 
@@ -9,11 +11,16 @@ import org.springframework.stereotype.Component
 @Component
 @Logging
 class OrderWriter(
-    private val orderRepository: OrderRepository
+    private val orderRepository: OrderRepository,
+    private val orderMetaDataRepository: OrderMetaDataRepository
 ) {
 
     fun save(order: Order) {
         orderRepository.save(order)
+    }
+
+    fun save(orderMetaData: OrderMetaData) {
+        orderMetaDataRepository.save(orderMetaData)
     }
 
     fun delete(order: Order) {

--- a/src/main/kotlin/com/flab/ticketing/order/service/OrderService.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/service/OrderService.kt
@@ -21,7 +21,6 @@ import com.flab.ticketing.order.entity.OrderMetaData
 import com.flab.ticketing.order.entity.Reservation
 import com.flab.ticketing.order.enums.OrderCancelReasons
 import com.flab.ticketing.order.exception.OrderErrorInfos
-import com.flab.ticketing.order.repository.OrderMetaDataRepository
 import com.flab.ticketing.order.repository.reader.CartReader
 import com.flab.ticketing.order.repository.reader.OrderReader
 import com.flab.ticketing.order.repository.writer.CartWriter
@@ -46,7 +45,6 @@ class OrderService(
     private val orderWriter: OrderWriter,
     private val tossPaymentClient: TossPaymentClient,
     private val fileService: FileService,
-    private val orderMetaDataRepository: OrderMetaDataRepository,
     @Value("\${service.url}") private val serviceUrl: String
 ) {
 
@@ -67,7 +65,7 @@ class OrderService(
             userUid = user.uid
         )
 
-        orderMetaDataRepository.save(orderMetaData)
+        orderWriter.save(orderMetaData)
 
         return OrderInfoResponse(orderMetaData.orderId, orderMetaData.amount)
     }

--- a/src/main/kotlin/com/flab/ticketing/order/service/client/TossPaymentClient.kt
+++ b/src/main/kotlin/com/flab/ticketing/order/service/client/TossPaymentClient.kt
@@ -5,6 +5,7 @@ import com.flab.ticketing.common.aop.Logging
 import com.flab.ticketing.common.exception.CommonErrorInfos
 import com.flab.ticketing.common.exception.ExternalAPIException
 import com.flab.ticketing.common.exception.InternalServerException
+import com.flab.ticketing.common.utils.Base64Utils
 import com.flab.ticketing.order.dto.request.OrderConfirmRequest
 import com.flab.ticketing.order.dto.service.TossPayConfirmResponse
 import com.flab.ticketing.order.dto.service.TossPayErrorResponse
@@ -46,7 +47,7 @@ class TossPaymentClient(
 
         val response = restClient.post()
             .uri(URI.create("$tossServerUrl$confirmUri"))
-            .header(HttpHeaders.AUTHORIZATION, "Basic $tossAccessToken")
+            .header(HttpHeaders.AUTHORIZATION, "Basic ${Base64Utils.encode(tossAccessToken + ":")}")
             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
             .body(tossOrderConfirmRequest)
             .retrieve()
@@ -65,7 +66,7 @@ class TossPaymentClient(
     fun cancel(paymentKey: String, reason: String) {
         restClient.post()
             .uri(URI.create("$tossServerUrl${String.format(cancelUriFormat, paymentKey)}"))
-            .header(HttpHeaders.AUTHORIZATION, "Basic $tossAccessToken")
+            .header(HttpHeaders.AUTHORIZATION, "Basic ${Base64Utils.encode(tossAccessToken + ":")}")
             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
             .body(TossOrderCancelRequest(reason))
             .retrieve()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,7 +52,7 @@ jwt:
 service:
   url: https://minturtle.kro.kr
   toss:
-    url: https://api.tosspayments.com/
+    url: https://api.tosspayments.com
     confirm-uri: /v1/payments/confirm
     cancel-uri: /v1/payments/%s/cancel
     access-token: ${TOSS_ACCESS_TOKEN}
@@ -152,10 +152,10 @@ jwt:
 service:
   url: http://localhost
   toss:
-    url: https://api.tosspayments.com/
+    url: https://api.tosspayments.com
     confirm-uri: /v1/payments/confirm
     cancel-uri: /v1/payments/%s/cancel
-    access-token: dGVzdF9za196WExrS0V5cE5BcldtbzUwblgzbG1lYXhZRzVSOg== # Toss Payments 임시 키
+    access-token: test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6 # Toss Payments 임시 키
 
 logging:
   pattern:

--- a/src/test/kotlin/com/flab/ticketing/common/OrderTestDataGenerator.kt
+++ b/src/test/kotlin/com/flab/ticketing/common/OrderTestDataGenerator.kt
@@ -11,7 +11,7 @@ object OrderTestDataGenerator {
     fun createOrder(
         uid: String = "order-001",
         user: User,
-        payment: Order.Payment = Order.Payment(10000, "KAKAO_PAY")
+        payment: Order.Payment = Order.Payment(10000, "KAKAO_PAY", "paymentkey")
     ): Order {
         return Order(
             uid,

--- a/src/test/kotlin/com/flab/ticketing/order/entity/OrderTest.kt
+++ b/src/test/kotlin/com/flab/ticketing/order/entity/OrderTest.kt
@@ -16,7 +16,7 @@ class OrderTest : UnitTest() {
             val order = Order(
                 "order001",
                 user,
-                payment = Order.Payment(1000, "토스 페이")
+                payment = Order.Payment(1000, "토스 페이", "paymentkey")
             )
 
             order.name shouldBe ""
@@ -31,7 +31,7 @@ class OrderTest : UnitTest() {
             val order = Order(
                 "order001",
                 user,
-                payment = Order.Payment(1000, "토스 페이")
+                payment = Order.Payment(1000, "토스 페이", "paymentkey")
             )
 
             order.addReservation(performanceDateTime, seats[0])
@@ -52,7 +52,7 @@ class OrderTest : UnitTest() {
             val order = Order(
                 "order001",
                 user,
-                payment = Order.Payment(1000, "토스 페이")
+                payment = Order.Payment(1000, "토스 페이", "paymentkey")
             )
 
             order.addReservation(performance1.performanceDateTime[0], performance1.performancePlace.seats[0])

--- a/src/test/kotlin/com/flab/ticketing/order/integration/OrderIntegrationTest.kt
+++ b/src/test/kotlin/com/flab/ticketing/order/integration/OrderIntegrationTest.kt
@@ -17,6 +17,7 @@ import com.flab.ticketing.order.dto.service.TossPayConfirmResponse
 import com.flab.ticketing.order.dto.service.TossPayErrorResponse
 import com.flab.ticketing.order.entity.Cart
 import com.flab.ticketing.order.entity.Order
+import com.flab.ticketing.order.entity.OrderMetaData
 import com.flab.ticketing.order.enums.TossPayCancelErrorCode
 import com.flab.ticketing.order.enums.TossPayConfirmErrorCode
 import com.flab.ticketing.order.exception.OrderErrorInfos
@@ -175,25 +176,28 @@ class OrderIntegrationTest : IntegrationTest() {
             )
             val performanceDateTime = performance.performanceDateTime[0]
             val seats = performance.performancePlace.seats
+            val carts = listOf(
+                Cart("cart1", seats[0], performanceDateTime, user),
+                Cart("cart2", seats[1], performanceDateTime, user)
+            )
 
             userRepository.save(user)
             savePerformance(listOf(performance))
-
-            val order = OrderTestDataGenerator.createOrder(
-                user = user,
-                payment = Order.Payment(performance.price * 2, "카드")
+            cartRepository.saveAll(carts)
+            orderMetaDataRepository.save(
+                OrderMetaData(
+                    "order-001",
+                    performance.price * 2,
+                    carts.map { it.uid },
+                    user.uid
+                )
             )
-
-            order.addReservation(performanceDateTime, seats[0])
-            order.addReservation(performanceDateTime, seats[1])
-
-            orderRepository.save(order)
 
             val orderConfirmRequest = OrderConfirmRequest(
                 paymentType = "카드",
-                orderId = order.uid,
+                orderId = "order-001",
                 paymentKey = "payment001",
-                amount = order.payment.totalPrice
+                amount = performance.price * 2
             )
 
             val tossPayApiConfirmResp = setUpTossPaymentConfirmResponse(orderConfirmRequest)
@@ -210,11 +214,13 @@ class OrderIntegrationTest : IntegrationTest() {
                     .andDo(print())
                     .andReturn()
 
-                then("토스 결제 승인 API를 호출하고, Order의 상태를 COMPLETED로 바꾼다.") {
+                then("토스 결제 승인 API를 호출하고, Order를 저장한다.") {
                     mvcResult.response.status shouldBe HttpStatus.OK.value()
-                    val actual = orderRepository.findByUid(order.uid)!!
+                    val actual = orderRepository.findByUid("order-001")!!
 
-                    actual.payment.paymentKey!! shouldBeEqual tossPayApiConfirmResp!!.paymentKey
+                    actual.user shouldBeEqual user
+                    actual.reservations.size shouldBe 2
+                    actual.payment.paymentKey shouldBeEqual tossPayApiConfirmResp!!.paymentKey
                     actual.status shouldBe Order.OrderStatus.COMPLETED
                 }
             }
@@ -227,32 +233,37 @@ class OrderIntegrationTest : IntegrationTest() {
             )
             val performanceDateTime = performance.performanceDateTime[0]
             val seats = performance.performancePlace.seats
+            val carts = listOf(
+                Cart("cart1", seats[0], performanceDateTime, user),
+                Cart("cart2", seats[1], performanceDateTime, user)
+            )
 
             userRepository.save(user)
             savePerformance(listOf(performance))
+            cartRepository.saveAll(carts)
 
-            val order = OrderTestDataGenerator.createOrder(
-                user = user,
-                payment = Order.Payment(performance.price * 2, "카드")
+            orderMetaDataRepository.save(
+                OrderMetaData(
+                    "order-001",
+                    performance.price * 2,
+                    carts.map { it.uid },
+                    user.uid
+                )
             )
-
-            order.addReservation(performanceDateTime, seats[0])
-            order.addReservation(performanceDateTime, seats[1])
-
-            orderRepository.save(order)
 
             val orderConfirmRequest = OrderConfirmRequest(
                 paymentType = "카드",
-                orderId = order.uid,
+                orderId = "order-001",
                 paymentKey = "payment001",
-                amount = order.payment.totalPrice
+                amount = performance.price * 2
             )
+
             `when`("다른 유저로 Order 주문 확정 API 호출 시") {
                 val user2 = UserTestDataGenerator.createUser(
                     uid = "user002",
                     email = "email2@email.com"
                 )
-                userRepository.save(user)
+                userRepository.save(user2)
                 val jwt = createJwt(user2)
 
                 val uri = "/api/orders/toss/confirm"
@@ -279,26 +290,31 @@ class OrderIntegrationTest : IntegrationTest() {
             )
             val performanceDateTime = performance.performanceDateTime[0]
             val seats = performance.performancePlace.seats
+            val carts = listOf(
+                Cart("cart1", seats[0], performanceDateTime, user),
+                Cart("cart2", seats[1], performanceDateTime, user)
+            )
 
             userRepository.save(user)
             savePerformance(listOf(performance))
+            cartRepository.saveAll(carts)
 
-            val order = OrderTestDataGenerator.createOrder(
-                user = user,
-                payment = Order.Payment(performance.price * 2, "카드")
+            orderMetaDataRepository.save(
+                OrderMetaData(
+                    "order-001",
+                    performance.price * 2,
+                    carts.map { it.uid },
+                    user.uid
+                )
             )
-
-            order.addReservation(performanceDateTime, seats[0])
-            order.addReservation(performanceDateTime, seats[1])
-
-            orderRepository.save(order)
 
             val orderConfirmRequest = OrderConfirmRequest(
                 paymentType = "카드",
-                orderId = order.uid,
+                orderId = "order-001",
                 paymentKey = "payment001",
-                amount = order.payment.totalPrice
+                amount = performance.price * 2
             )
+
             val tossPayResponse = setUpTossPaymentFailConfirmResponse()
 
             `when`("결제 승인 API를 호출 시") {
@@ -314,14 +330,14 @@ class OrderIntegrationTest : IntegrationTest() {
                     .andDo(print())
                     .andReturn()
 
-                then("토스 페이 API의 응답 정보를 반환하고, 주문을 PENDING 상태로 변경한다.") {
+                then("토스 페이 API의 응답 정보를 반환하고, 주문 확정 작업을 롤백한다.") {
                     checkError(
                         mvcResult,
                         HttpStatus.NOT_FOUND,
                         CommonErrorInfos.EXTERNAL_API_ERROR.code,
                         TOSS_EXCEPTION_PREFIX + tossPayResponse.message
                     )
-                    orderRepository.findByUid(order.uid)!!.status shouldBe Order.OrderStatus.PENDING
+                    orderRepository.findByUid("order-001") shouldBe null
                 }
             }
 
@@ -480,7 +496,7 @@ class OrderIntegrationTest : IntegrationTest() {
         }
 
 
-        given("주문의 상태가 PENDING인 주문이 존재할 때") {
+        given("주문의 상태가 CANCELED인 주문이 존재할 때") {
             val user = UserTestDataGenerator.createUser()
             val performance = PerformanceTestDataGenerator.createPerformance()
 
@@ -488,31 +504,31 @@ class OrderIntegrationTest : IntegrationTest() {
             order.addReservation(performance.performanceDateTime[0], performance.performancePlace.seats[0])
             order.status = Order.OrderStatus.COMPLETED
 
-            val pendingOrder = OrderTestDataGenerator.createOrder(
+            val canceledOrder = OrderTestDataGenerator.createOrder(
                 uid = "order-002",
                 user = user,
                 payment = Order.Payment(1000, "카드", "abc123")
             )
-            pendingOrder.addReservation(performance.performanceDateTime[0], performance.performancePlace.seats[1])
-            pendingOrder.status = Order.OrderStatus.PENDING
+            canceledOrder.addReservation(performance.performanceDateTime[0], performance.performancePlace.seats[1])
+            canceledOrder.status = Order.OrderStatus.CANCELED
 
             userRepository.save(user)
             savePerformance(listOf(performance))
-            orderRepository.saveAll(listOf(order, pendingOrder))
+            orderRepository.saveAll(listOf(order, canceledOrder))
 
-            `when`("주문이 Pending 상태인 주문을 조회할 시") {
+            `when`("주문이 CANCELED 상태인 주문을 조회할 시") {
                 val uri = "/api/orders"
                 val jwt = createJwt(user)
 
                 val mvcResult = mockMvc.perform(
                     get(uri)
-                        .param("status", Order.OrderStatus.PENDING.toString())
+                        .param("status", Order.OrderStatus.CANCELED.toString())
                         .header(HttpHeaders.AUTHORIZATION, "Bearer $jwt")
                 ).andDo(
                     print()
                 ).andReturn()
 
-                then("PENDING 상태의 주문을 반환한다.") {
+                then("CANCELED 상태의 주문을 반환한다.") {
                     val actual = objectMapper.readValue<CursoredResponse<OrderSummarySearchResult>>(
                         mvcResult.response.contentAsString,
                         objectMapper.typeFactory.constructParametricType(
@@ -522,7 +538,7 @@ class OrderIntegrationTest : IntegrationTest() {
                     )
 
                     actual.data.size shouldBe 1
-                    actual.data[0].uid shouldBe pendingOrder.uid
+                    actual.data[0].uid shouldBe canceledOrder.uid
                 }
             }
 

--- a/src/test/kotlin/com/flab/ticketing/order/repository/OrderRepositoryTest.kt
+++ b/src/test/kotlin/com/flab/ticketing/order/repository/OrderRepositoryTest.kt
@@ -23,7 +23,6 @@ import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.data.domain.PageRequest
 
 class OrderRepositoryTest : RepositoryTest() {
 
@@ -93,7 +92,11 @@ class OrderRepositoryTest : RepositoryTest() {
 
             val sortedOrders = orders.sortedByDescending { it.id }
 
-            val actual = orderRepository.findByUser(user.uid, CursorInfoDto(cursor = sortedOrders[2].uid), OrderSearchConditions())
+            val actual = orderRepository.findByUser(
+                user.uid,
+                CursorInfoDto(cursor = sortedOrders[2].uid),
+                OrderSearchConditions()
+            )
             val expectedUidList = listOf(sortedOrders[2].uid, sortedOrders[3].uid, sortedOrders[4].uid)
 
             actual.map { it.uid } shouldContainExactly expectedUidList
@@ -104,7 +107,7 @@ class OrderRepositoryTest : RepositoryTest() {
             val user = UserTestDataGenerator.createUser()
             val performance = PerformanceTestDataGenerator.createPerformance()
 
-            val order = Order("order-001", user, Order.Payment(0, "카드"))
+            val order = Order("order-001", user, Order.Payment(0, "카드", "paymentkey"))
 
             userRepository.save(user)
             performanceRepository.save(performance)
@@ -117,7 +120,7 @@ class OrderRepositoryTest : RepositoryTest() {
 
         }
 
-        "주문을 조회할 때 Status로 조회할 수 있다."{
+        "주문을 조회할 때 Status로 조회할 수 있다." {
             val user = UserTestDataGenerator.createUser()
             val performance = PerformanceTestDataGenerator.createPerformance(
                 place = PerformanceTestDataGenerator.createPerformancePlace(numSeats = 10)


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #112 

## 📝작업 내용

> 주문 API 수정
주문 생성 API를 변경, 생성 API 호출시 주문 임시 데이터만 생성해 저장하고, 주문 확정 API 호출시 실질적으로 Order 객체를 생성하고 Cart를 제거하도록 변경하였습니다.

