### PR TITLE
Fix: Performance 검색(ES) 시 검색 결과가 Empty List면 Exception이 나타나는 오류

### DIFF
--- a/src/main/kotlin/com/flab/ticketing/performance/dto/service/PerformanceSearchResult.kt
+++ b/src/main/kotlin/com/flab/ticketing/performance/dto/service/PerformanceSearchResult.kt
@@ -3,6 +3,6 @@ package com.flab.ticketing.performance.dto.service
 import com.flab.ticketing.performance.entity.PerformanceSearchSchema
 
 data class PerformanceSearchResult(
-    val cursor: List<Any>,
+    val cursor: List<Any>?,
     val data: List<PerformanceSearchSchema>
 )

--- a/src/main/kotlin/com/flab/ticketing/performance/repository/dsl/EsPerformanceSearchRepositoryImpl.kt
+++ b/src/main/kotlin/com/flab/ticketing/performance/repository/dsl/EsPerformanceSearchRepositoryImpl.kt
@@ -12,6 +12,7 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.data.elasticsearch.client.elc.NativeQueryBuilder
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations
+import org.springframework.data.elasticsearch.core.SearchHit
 import org.springframework.data.elasticsearch.core.search
 import java.time.format.DateTimeFormatter
 
@@ -38,7 +39,7 @@ class EsPerformanceSearchRepositoryImpl(
 
         val searchHits = elasticsearchOperations.search<PerformanceSearchSchema>(nativeQuery).searchHits
 
-        val nextCursor = searchHits.last().sortValues
+        val nextCursor = createNextCursor(searchHits, limit)
 
         return PerformanceSearchResult(nextCursor, searchHits.map { it.content })
     }
@@ -108,5 +109,13 @@ class EsPerformanceSearchRepositoryImpl(
         }
 
         return this
+    }
+
+
+    private fun createNextCursor(searchHits : List<SearchHit<PerformanceSearchSchema>>, expectedSize: Int) : List<Any>?{
+        if(searchHits.size == expectedSize){
+            return searchHits.last().sortValues
+        }
+        return null
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,7 +34,11 @@ spring:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
       password: ${REDIS_PASSWORD}
-
+    elasticsearch:
+      repositories:
+        enabled: true
+      url: ${ES_HOST}
+      api-key: ${ES_API_KEY}
 server:
   servlet:
     encoding:

--- a/src/test/kotlin/com/flab/ticketing/performance/repository/PerformanceSearchRepositoryTest.kt
+++ b/src/test/kotlin/com/flab/ticketing/performance/repository/PerformanceSearchRepositoryTest.kt
@@ -301,6 +301,19 @@ class PerformanceSearchRepositoryTest : StringSpec() {
 
         }
 
+        "Performance 검색 결과가 존재하지 않을 시, 빈 data 배열과 null cursor를 반환한다."{
+            // given
+
+            // when
+            val (cursor, data) = performanceSearchRepository.search(PerformanceSearchConditions(), null, 10)
+
+
+            // then
+            cursor shouldBe null
+            data.size shouldBe 0
+
+        }
+
     }
 
     override suspend fun beforeEach(testCase: TestCase) {

--- a/src/test/kotlin/com/flab/ticketing/performance/service/PerformanceServiceTest.kt
+++ b/src/test/kotlin/com/flab/ticketing/performance/service/PerformanceServiceTest.kt
@@ -8,9 +8,11 @@ import com.flab.ticketing.common.entity.BaseEntity
 import com.flab.ticketing.common.exception.NotFoundException
 import com.flab.ticketing.order.repository.reader.CartReader
 import com.flab.ticketing.order.repository.reader.ReservationReader
+import com.flab.ticketing.performance.dto.request.PerformanceSearchConditions
 import com.flab.ticketing.performance.dto.response.PerformanceDateDetailResponse
 import com.flab.ticketing.performance.dto.response.PerformanceDetailResponse
 import com.flab.ticketing.performance.dto.service.PerformanceDateSummaryResult
+import com.flab.ticketing.performance.dto.service.PerformanceSearchResult
 import com.flab.ticketing.performance.dto.service.PerformanceStartEndDateResult
 import com.flab.ticketing.performance.dto.service.PerformanceSummarySearchResult
 import com.flab.ticketing.performance.entity.Performance
@@ -24,6 +26,8 @@ import io.kotest.matchers.equals.shouldBeEqual
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
 import java.time.ZonedDateTime
 
 class PerformanceServiceTest : UnitTest() {
@@ -31,7 +35,7 @@ class PerformanceServiceTest : UnitTest() {
     private val performanceReader: PerformanceReader = mockk()
     private val reservationReader: ReservationReader = mockk()
     private val cartReader: CartReader = mockk()
-    private val objectMapper = ObjectMapper()
+    private val objectMapper = spyk<ObjectMapper>()
     private val performanceService: PerformanceService =
         PerformanceService(performanceReader, reservationReader, cartReader, objectMapper)
 
@@ -199,6 +203,22 @@ class PerformanceServiceTest : UnitTest() {
             val actual = performanceService.search(CursorInfoDto())
 
             actual shouldContainExactly expected
+        }
+
+        "performance Search 검색 cursor가 null일 시 cursor를 String으로 변환하지 않고 null을 반환한다."{
+
+            //given
+            val givenReturnData = PerformanceSearchResult(null, listOf())
+
+            every { performanceReader.search(any<PerformanceSearchConditions>(), any(), any()) } returns givenReturnData
+
+            // when
+            val (cursor, _) = performanceService.search(CursorInfoDto(), PerformanceSearchConditions())
+
+
+            // then
+            cursor shouldBe null
+            verify(exactly = 0){ objectMapper.writeValueAsString(any<List<Any>>()) }
         }
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #118 

## 📝작업 내용

> Performance 검색(ES) 시 검색 결과가 Empty List면 Exception이 나타나는 오류
> - 검색 결과가 사용자의 입력 limit보다 작다면 cursor를 null을 반환하도록 변경

