### PR TITLE
chore: 공연 조회 API 캐시 적용

### DIFF
--- a/src/main/kotlin/com/flab/ticketing/performance/service/PerformanceService.kt
+++ b/src/main/kotlin/com/flab/ticketing/performance/service/PerformanceService.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.flab.ticketing.common.config.CacheConfig
 import com.flab.ticketing.common.dto.response.CursoredResponse
-import com.flab.ticketing.common.dto.response.ListedResponse
 import com.flab.ticketing.common.dto.service.CursorInfoDto
 import com.flab.ticketing.common.enums.CacheType
 import com.flab.ticketing.common.utils.Base64Utils
@@ -47,15 +46,15 @@ class PerformanceService(
     }
 
 
-//    @Caching(
-//        cacheable = [
-//            Cacheable(
-//                cacheManager = CacheConfig.COMPOSITE_CACHE_MANAGER_NAME,
-//                cacheNames = [CacheType.PRODUCT_CACHE_NAME],
-//                key = "'performance_' + (#cursorInfoDto.cursor ?: 'first_page') + '_' + #cursorInfoDto.limit"
-//            )
-//        ]
-//    )
+    @Caching(
+        cacheable = [
+            Cacheable(
+                cacheManager = CacheConfig.LOCAL_CACHE_MANAGER_NAME,
+                cacheNames = [CacheType.PRODUCT_CACHE_NAME],
+                key = "'performance_' + (#cursorInfoDto.cursor ?: 'first_page') + '_' + #cursorInfoDto.limit"
+            )
+        ]
+    )
     fun search(
         cursorInfoDto: CursorInfoDto
     ): List<PerformanceSummarySearchResult> {

--- a/src/test/kotlin/com/flab/ticketing/performance/service/PerformanceServiceCacheTest.kt
+++ b/src/test/kotlin/com/flab/ticketing/performance/service/PerformanceServiceCacheTest.kt
@@ -9,7 +9,6 @@ import com.flab.ticketing.performance.dto.service.PerformanceStartEndDateResult
 import com.flab.ticketing.performance.repository.reader.PerformanceReader
 import com.ninjasquad.springmockk.MockkBean
 import com.ninjasquad.springmockk.SpykBean
-import io.kotest.core.annotation.Ignored
 import io.kotest.matchers.collections.shouldContainExactly
 import io.mockk.every
 import io.mockk.verify
@@ -17,8 +16,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.cache.CacheManager
 
 
-
-@Ignored
 class PerformanceServiceCacheTest : IntegrationTest() {
 
     @MockkBean
@@ -63,7 +60,9 @@ class PerformanceServiceCacheTest : IntegrationTest() {
         }
 
 
-        given("search 메서드가 Cache가 적용되었을 때 - CompositeCacheManger 테스트"){
+
+
+        given("search 메서드가 Cache가 적용되었을 때 - LocalCacheManger 테스트") {
             val performances =
                 PerformanceTestDataGenerator.createPerformanceGroupbyRegion(performanceCount = 5)
 
@@ -82,15 +81,14 @@ class PerformanceServiceCacheTest : IntegrationTest() {
                 performanceService.search(cursorDto)
                 performanceService.search(cursorDto)
 
-                then("두개의 CacheManager에서 모두 값을 조회한다.") {
+                then("LocalCacheManger에서 모두 값을 조회한다.") {
                     verify(exactly = 2) { localCacheManager.getCache(CacheType.PRODUCT_CACHE_NAME) }
-                    verify(exactly = 2) { globalCacheManager.getCache(CacheType.PRODUCT_CACHE_NAME) }
                 }
             }
 
         }
 
-        given("region list를 조회할 때"){
+        given("region list를 조회할 때") {
             // given
             val regions = MutableList(5) {
                 PerformanceTestDataGenerator.createRegion("region$it")
@@ -98,12 +96,12 @@ class PerformanceServiceCacheTest : IntegrationTest() {
 
             every { performanceReader.getRegions() } returns regions
 
-            `when`("두번이상 region list를 조회한다면"){
+            `when`("두번이상 region list를 조회한다면") {
                 val result1 = performanceService.getRegions()
                 val result2 = performanceService.getRegions()
 
-                then("두번째 부터는 캐싱된다."){
-                    verify(exactly = 1) {  performanceReader.getRegions() }
+                then("두번째 부터는 캐싱된다.") {
+                    verify(exactly = 1) { performanceReader.getRegions() }
                     result1 shouldContainExactly result2
                 }
             }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #147

## 📝작업 내용

> 공연 조회 API 캐시 적용, Spring 인스턴스가 하나기 때문에 일단 Local Cache만 적용하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
